### PR TITLE
Recommend use of `sudo -v` over `sudo echo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ on Linux, you can run
 ``` bash
 sync; echo 3 | sudo tee /proc/sys/vm/drop_caches
 ```
-To use this specific command with Hyperfine, call `sudo echo` to temporarily gain sudo permissions
+To use this specific command with Hyperfine, call `sudo -v` to temporarily gain sudo permissions
 and then call:
 ``` bash
 hyperfine --prepare 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches' 'grep -R TODO *'


### PR DESCRIPTION
`sudo -v` (or `sudo --validate`) updates the sudo credentials cache without running any commands.

It's slightly safer than `sudo echo` under the unlikely chance that `~/.local/bin/echo` (or elsewhere on the PATH) could be set to something malicious.