### PR TITLE
Enable compatibility with windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ version = "0.4.0"
 colored = "1.6"
 indicatif = "0.9"
 statistical = "0.1"
-libc = "0.2"
 atty = "0.2.2"
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+libc = "0.2"
 
 [dependencies.clap]
 version = "2"

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -100,8 +100,8 @@ pub fn time_shell_command(
 ) -> io::Result<(TimingResult, bool)> {
     let start = Instant::now();
 
-    let status = Command::new("sh")
-        .arg("-c")
+    let status = Command::new("cmd")
+        // .arg("-c")
         .arg(shell_cmd)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -129,8 +129,8 @@ pub fn time_shell_command(
     Ok((
         TimingResult {
             time_real,
-            time_user: 0,
-            time_system: 0,
+            time_user: 0f64,
+            time_system: 0f64,
         },
         status.success(),
     ))

--- a/src/hyperfine/cputime.rs
+++ b/src/hyperfine/cputime.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "windows"))]
+
 use libc::{getrusage, rusage, RUSAGE_CHILDREN};
 
 use std::mem;

--- a/src/hyperfine/cputime.rs
+++ b/src/hyperfine/cputime.rs
@@ -1,4 +1,5 @@
 use libc::{getrusage, rusage, RUSAGE_CHILDREN};
+
 use std::mem;
 
 use hyperfine::internal::Second;

--- a/src/hyperfine/mod.rs
+++ b/src/hyperfine/mod.rs
@@ -1,6 +1,8 @@
 pub mod benchmark;
 pub mod format;
 pub mod internal;
-pub mod cputime;
 pub mod outlier_detection;
 pub mod warnings;
+
+#[cfg(not(target_os = "windows"))]
+pub mod cputime; 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,13 +147,14 @@ fn main() {
         },
     };
 
+    if options.output_style == OutputStyleOption::Basic {
+        colored::control::set_override(false);
+    }
+
     if cfg!(target_os = "windows") {
         options.output_style = OutputStyleOption::Basic;
     }
 
-    if options.output_style == OutputStyleOption::Basic {
-        colored::control::set_override(false);
-    }
     if matches.is_present("ignore-failure") {
         options.failure_action = CmdFailureAction::Ignore;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 extern crate atty;
-
 #[macro_use]
 extern crate clap;
 extern crate colored;
 extern crate indicatif;
-extern crate libc;
 extern crate statistical;
+
+#[cfg(not(target_os = "windows"))]
+extern crate libc;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,10 @@ fn main() {
         },
     };
 
+    if cfg!(target_os = "windows") {
+        options.output_style = OutputStyleOption::Basic;
+    }
+
     if options.output_style == OutputStyleOption::Basic {
         colored::control::set_override(false);
     }


### PR DESCRIPTION
In response to #28 this adds conditional compilation to all libc portions that do not work on a Windows target.

Additionally as the indicatif bar does not render properly on Powershell, this forces Basic output if it is buildling/running on Windows.

This is a preliminary PR so we can get a better idea of a desired direction. There's for sure a bunch of refactoring that can be done and cleanup also.