### PR TITLE
Don't disable styling on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,11 +146,7 @@ fn main() {
             OutputStyleOption::Basic
         },
     };
-
-    if cfg!(target_os = "windows") {
-        options.output_style = OutputStyleOption::Basic;
-    }
-
+    
     if options.output_style == OutputStyleOption::Basic {
         colored::control::set_override(false);
     }


### PR DESCRIPTION
Since it seems the progress bar actually does work correctly on Windows, don't automatically set style to Basic. This resolves point 4 on #33.

However, there are some issues with coloring on default PowerShell windows as can be observed in the following screenshot.
<img width="773" alt="screen shot 2018-02-11 at 10 27 06 pm" src="https://user-images.githubusercontent.com/8147610/36082878-6e5b8712-0f7b-11e8-8144-9467a751b5cf.png">
