### PR TITLE
Windows colors

### DIFF
--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -24,6 +24,9 @@ pub enum OutputStyleOption {
 
     /// Output with full color and formatting
     Full,
+
+    /// Keep elements such as progress bar, but use no coloring
+    NoColor,
 }
 
 /// A set of options for hyperfine
@@ -64,14 +67,14 @@ impl Default for HyperfineOptions {
 pub fn get_progress_bar(length: u64, msg: &str, option: &OutputStyleOption) -> ProgressBar {
     let progressbar_style = match *option {
         OutputStyleOption::Basic => ProgressStyle::default_bar(),
-        OutputStyleOption::Full => ProgressStyle::default_spinner()
+        OutputStyleOption::Full | OutputStyleOption::NoColor => ProgressStyle::default_spinner()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
             .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
     };
 
     let progress_bar = match *option {
         OutputStyleOption::Basic => ProgressBar::hidden(),
-        OutputStyleOption::Full => ProgressBar::new(length),
+        OutputStyleOption::Full | OutputStyleOption::NoColor => ProgressBar::new(length),
     };
     progress_bar.set_style(progressbar_style.clone());
     progress_bar.enable_steady_tick(80);

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -67,14 +67,14 @@ impl Default for HyperfineOptions {
 pub fn get_progress_bar(length: u64, msg: &str, option: &OutputStyleOption) -> ProgressBar {
     let progressbar_style = match *option {
         OutputStyleOption::Basic => ProgressStyle::default_bar(),
-        OutputStyleOption::Full | OutputStyleOption::NoColor => ProgressStyle::default_spinner()
+        _ => ProgressStyle::default_spinner()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
             .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
     };
 
     let progress_bar = match *option {
         OutputStyleOption::Basic => ProgressBar::hidden(),
-        OutputStyleOption::Full | OutputStyleOption::NoColor => ProgressBar::new(length),
+        _ => ProgressBar::new(length),
     };
     progress_bar.set_style(progressbar_style.clone());
     progress_bar.enable_steady_tick(80);

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,11 +115,12 @@ fn main() {
                 .short("s")
                 .takes_value(true)
                 .value_name("TYPE")
-                .possible_values(&["auto", "basic", "full"])
+                .possible_values(&["auto", "basic", "full", "nocolor"])
                 .help(
                     "Set output style type (default: auto). Set this to 'basic' to disable output \
                      coloring and interactive elements. Set it to 'full' to enable all effects \
-                     even if no interactive terminal was detected.",
+                     even if no interactive terminal was detected. Setting to 'nocolor' maintains \
+                     all advanced output, but uses no colorization.",
                 ),
         )
         .arg(
@@ -149,6 +150,7 @@ fn main() {
     options.output_style = match matches.value_of("style") {
         Some("full") => OutputStyleOption::Full,
         Some("basic") => OutputStyleOption::Basic,
+        Some("nocolor") => OutputStyleOption::NoColor,
         _ => if atty::is(Stream::Stdout) {
             OutputStyleOption::Full
         } else {
@@ -156,7 +158,14 @@ fn main() {
         },
     };
 
-    if options.output_style == OutputStyleOption::Basic {
+    // We default Windows to NoColor if full or auto had been specified.
+    if cfg!(windows) && options.output_style == OutputStyleOption::Full {
+        options.output_style = OutputStyleOption::NoColor;
+    }
+
+    if options.output_style == OutputStyleOption::Basic
+        || options.output_style == OutputStyleOption::NoColor
+    {
         colored::control::set_override(false);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,14 +158,12 @@ fn main() {
         },
     };
 
-    // We default Windows to NoColor if full or auto had been specified.
+    // We default Windows to NoColor if full had been specified.
     if cfg!(windows) && options.output_style == OutputStyleOption::Full {
         options.output_style = OutputStyleOption::NoColor;
     }
 
-    if options.output_style == OutputStyleOption::Basic
-        || options.output_style == OutputStyleOption::NoColor
-    {
+    if options.output_style != OutputStyleOption::Full {
         colored::control::set_override(false);
     }
 


### PR DESCRIPTION
This adds a new style value 'NoColor' that maintains most output styles, but removes coloring from output. On Windows, this is the default setting if Full would have been used.