### PR TITLE
Add markdown support.

### DIFF
--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -3,10 +3,11 @@ use super::{ExportEntry, Exporter};
 use csv::WriterBuilder;
 use std::io::{Error, ErrorKind, Result};
 
+#[derive(Default)]
 pub struct CsvExporter {}
 
 impl Exporter for CsvExporter {
-    fn serialize(&self, results: &Vec<ExportEntry>) -> Result<String> {
+    fn serialize(&self, results: &Vec<ExportEntry>) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
         for res in results {
             writer.serialize(res)?;
@@ -14,14 +15,6 @@ impl Exporter for CsvExporter {
 
         writer
             .into_inner()
-            .ok()
-            .and_then(|bytes| String::from_utf8(bytes).ok())
-            .ok_or(Error::new(ErrorKind::Other, "Error serializing to CSV"))
-    }
-}
-
-impl CsvExporter {
-    pub fn new() -> Self {
-        CsvExporter {}
+            .map_err(|e| Error::new(ErrorKind::Other, e))
     }
 }

--- a/src/hyperfine/export/json.rs
+++ b/src/hyperfine/export/json.rs
@@ -2,23 +2,18 @@ use super::{ExportEntry, Exporter};
 
 use std::io::{Error, ErrorKind, Result};
 
-use serde_json::to_string_pretty;
+use serde_json::to_vec_pretty;
 
 #[derive(Serialize, Debug)]
 struct HyperfineSummary<'a> {
     results: &'a Vec<ExportEntry>,
 }
 
+#[derive(Default)]
 pub struct JsonExporter {}
 
 impl Exporter for JsonExporter {
-    fn serialize(&self, results: &Vec<ExportEntry>) -> Result<String> {
-        to_string_pretty(&HyperfineSummary { results }).map_err(|e| Error::new(ErrorKind::Other, e))
-    }
-}
-
-impl JsonExporter {
-    pub fn new() -> Self {
-        JsonExporter {}
+    fn serialize(&self, results: &Vec<ExportEntry>) -> Result<Vec<u8>> {
+        to_vec_pretty(&HyperfineSummary { results }).map_err(|e| Error::new(ErrorKind::Other, e))
     }
 }

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -1,0 +1,38 @@
+use super::{ExportEntry, Exporter};
+
+use std::io::Result;
+
+const MULTIPLIER: f64 = 1e3;
+
+#[derive(Default)]
+pub struct MarkdownExporter {}
+
+impl Exporter for MarkdownExporter {
+    fn serialize(&self, results: &Vec<ExportEntry>) -> Result<Vec<u8>> {
+        let mut destination = start_table();
+
+        for result in results {
+            add_table_row(&mut destination, result);
+        }
+
+        Ok(destination)
+    }
+}
+
+fn start_table() -> Vec<u8> {
+    "| Benchmark | Mean [ms] | Min. [ms] | Max. [ms] |\n|----|----|----|----|\n"
+        .bytes()
+        .collect()
+}
+fn add_table_row(dest: &mut Vec<u8>, entry: &ExportEntry) {
+    dest.extend(
+        format!(
+            "| {} | {:.1} ± {:.1} | {:.1} | {:.1} |\n",
+            entry.command.replace("|", "\\|"),
+            entry.mean * MULTIPLIER,
+            entry.stddev * MULTIPLIER,
+            entry.min * MULTIPLIER,
+            entry.max * MULTIPLIER
+        ).as_bytes(),
+    );
+}

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -27,7 +27,7 @@ fn start_table() -> Vec<u8> {
 fn add_table_row(dest: &mut Vec<u8>, entry: &ExportEntry) {
     dest.extend(
         format!(
-            "| {} | {:.1} ± {:.1} | {:.1} | {:.1} |\n",
+            "| `{}` | {:.1} ± {:.1} | {:.1} | {:.1} |\n",
             entry.command.replace("|", "\\|"),
             entry.mean * MULTIPLIER,
             entry.stddev * MULTIPLIER,

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,13 @@ fn main() {
                 .value_name("FILE")
                 .help("Export the timing results to the given file in JSON format."),
         )
+        .arg(
+            Arg::with_name("export-md")
+                .long("export-md")
+                .takes_value(true)
+                .value_name("FILE")
+                .help("Export the timing results to a markdown table in the given file"),
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.")
         .get_matches();
@@ -187,6 +194,9 @@ fn main() {
     }
     if let Some(filename) = matches.value_of("export-csv") {
         export_manager.add_exporter(ExportType::Csv, filename);
+    }
+    if let Some(filename) = matches.value_of("export-md") {
+        export_manager.add_exporter(ExportType::Markdown, filename);
     }
 
     // We default Windows to NoColor if full had been specified.

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,11 +153,11 @@ fn main() {
                 .help("Export the timing results to the given file in JSON format."),
         )
         .arg(
-            Arg::with_name("export-md")
-                .long("export-md")
+            Arg::with_name("export-markdown")
+                .long("export-markdown")
                 .takes_value(true)
                 .value_name("FILE")
-                .help("Export the timing results to a markdown table in the given file"),
+                .help("Export the timing results as a Markdown table to the given FILE."),
         )
         .help_message("Print this help message.")
         .version_message("Show version information.")
@@ -195,7 +195,7 @@ fn main() {
     if let Some(filename) = matches.value_of("export-csv") {
         export_manager.add_exporter(ExportType::Csv, filename);
     }
-    if let Some(filename) = matches.value_of("export-md") {
+    if let Some(filename) = matches.value_of("export-markdown") {
         export_manager.add_exporter(ExportType::Markdown, filename);
     }
 


### PR DESCRIPTION
Closes #44, adds export to markdown tables as an option.

I applied my changes on top of your recent changes. But I also derived Default for all exporters, so no more boilerplate impls for new(). And since we were just creating strings to change them to bytes, I made all serialization go directly to bytes instead.