### PR TITLE
Export list of runtimes to JSON

### DIFF
--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -302,5 +302,6 @@ pub fn run_benchmark(
         system_mean,
         t_min,
         t_max,
+        times_real,
     ))
 }

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -4,21 +4,6 @@ use std::io::{Error, ErrorKind, Result};
 
 use csv::WriterBuilder;
 
-use hyperfine::internal::Second;
-
-/// Set of values that will be exported.
-#[derive(Debug, Serialize)]
-pub struct CsvEntry {
-    command: String,
-    mean: Second,
-    stddev: Second,
-    user: Second,
-    system: Second,
-    min: Second,
-    max: Second,
-}
-
-
 #[derive(Default)]
 pub struct CsvExporter {}
 
@@ -26,15 +11,11 @@ impl Exporter for CsvExporter {
     fn serialize(&self, results: &Vec<ExportEntry>) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
         for res in results {
-            writer.serialize(&CsvEntry {
-                command: res.command.clone(),
-                mean: res.mean,
-                stddev: res.stddev,
-                user: res.user,
-                system: res.system,
-                min: res.min,
-                max: res.max,
-            })?;
+            // The list of times can not be exported to the CSV file - remove it:
+            let mut result = res.clone();
+            result.times = None;
+
+            writer.serialize(result)?;
         }
 
         writer

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -1,7 +1,23 @@
 use super::{ExportEntry, Exporter};
 
-use csv::WriterBuilder;
 use std::io::{Error, ErrorKind, Result};
+
+use csv::WriterBuilder;
+
+use hyperfine::internal::Second;
+
+/// Set of values that will be exported.
+#[derive(Debug, Serialize)]
+pub struct CsvEntry {
+    command: String,
+    mean: Second,
+    stddev: Second,
+    user: Second,
+    system: Second,
+    min: Second,
+    max: Second,
+}
+
 
 #[derive(Default)]
 pub struct CsvExporter {}
@@ -10,7 +26,15 @@ impl Exporter for CsvExporter {
     fn serialize(&self, results: &Vec<ExportEntry>) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
         for res in results {
-            writer.serialize(res)?;
+            writer.serialize(&CsvEntry {
+                command: res.command.clone(),
+                mean: res.mean,
+                stddev: res.stddev,
+                user: res.user,
+                system: res.system,
+                min: res.min,
+                max: res.max,
+            })?;
         }
 
         writer

--- a/src/hyperfine/export/mod.rs
+++ b/src/hyperfine/export/mod.rs
@@ -36,7 +36,8 @@ pub struct ExportEntry {
     max: Second,
 
     /// All run time measurements
-    times: Vec<Second>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    times: Option<Vec<Second>>,
 }
 
 impl ExportEntry {
@@ -59,7 +60,7 @@ impl ExportEntry {
             system,
             min,
             max,
-            times,
+            times: Some(times),
         }
     }
 }

--- a/src/hyperfine/export/mod.rs
+++ b/src/hyperfine/export/mod.rs
@@ -34,6 +34,9 @@ pub struct ExportEntry {
 
     /// Max time measured
     max: Second,
+
+    /// All run time measurements
+    times: Vec<Second>,
 }
 
 impl ExportEntry {
@@ -46,6 +49,7 @@ impl ExportEntry {
         system: Second,
         min: Second,
         max: Second,
+        times: Vec<Second>,
     ) -> Self {
         ExportEntry {
             command,
@@ -55,6 +59,7 @@ impl ExportEntry {
             system,
             min,
             max,
+            times,
         }
     }
 }


### PR DESCRIPTION
It's a shame that we have to introduce that `CsvEntry` struct but I didn't find a better way.

The resulting JSON file looks like this
``` json
{
  "results": [
    {
      "command": "sleep 0.2",
      "mean": 0.2043455445007143,
      "stddev": 0.0019188554787314525,
      "user": 0.0023347521428571428,
      "system": 0.002159442142857143,
      "min": 0.20007057271500004,
      "max": 0.207549326715,
      "times": [
        0.20007057271500004,
        0.20305231671500002,
        0.202839658715,
        0.205020261715,
        0.20467369571500003,
        0.20455664371500002,
        0.20604999871500002,
        0.20499965771500004,
        0.20321977971500003,
        0.20705682471500004,
        0.20308524271500004,
        0.203544831715,
        0.207549326715,
        0.20511881171500002
      ]
    },
    {
      "command": "sleep 0.3",
      "mean": 0.30501838271500006,
      "stddev": 0.001610254535237144,
      "user": 0.0036618289999999999,
      "system": 0.0015725459999999998,
      "min": 0.30210786171500006,
      "max": 0.30712019371500007,
      "times": [
        0.30562801371500006,
        0.30695781471500008,
        0.30459106071500005,
        0.30416734771500006,
        0.30712019371500007,
        0.30367873171500006,
        0.30409325871500006,
        0.305167409715,
        0.30667213471500007,
        0.30210786171500006
      ]
    }
  ]
}                                                                                                      
```

@stevepentland FYI.