### PR TITLE
Implement '--parameter-range var min max', see #19

### DIFF
--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -1,0 +1,38 @@
+use std::num;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum ParameterRangeError {
+    ParseIntError(num::ParseIntError),
+    EmptyRange,
+    TooLarge,
+}
+
+impl ParameterRangeError {
+    fn __description(&self) -> &str {
+        match *self {
+            ParameterRangeError::ParseIntError(ref e) => e.description(),
+            ParameterRangeError::EmptyRange => "Empty parameter range",
+            ParameterRangeError::TooLarge => "Parameter range is too large",
+        }
+    }
+}
+
+impl From<num::ParseIntError> for ParameterRangeError {
+    fn from(e: num::ParseIntError) -> ParameterRangeError {
+        ParameterRangeError::ParseIntError(e)
+    }
+}
+
+impl fmt::Display for ParameterRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.__description())
+    }
+}
+
+impl Error for ParameterRangeError {
+    fn description(&self) -> &str {
+        self.__description()
+    }
+}

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -3,35 +3,35 @@ use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
-pub enum ParameterRangeError {
+pub enum ParameterScanError {
     ParseIntError(num::ParseIntError),
     EmptyRange,
     TooLarge,
 }
 
-impl ParameterRangeError {
+impl ParameterScanError {
     fn __description(&self) -> &str {
         match *self {
-            ParameterRangeError::ParseIntError(ref e) => e.description(),
-            ParameterRangeError::EmptyRange => "Empty parameter range",
-            ParameterRangeError::TooLarge => "Parameter range is too large",
+            ParameterScanError::ParseIntError(ref e) => e.description(),
+            ParameterScanError::EmptyRange => "Empty parameter range",
+            ParameterScanError::TooLarge => "Parameter range is too large",
         }
     }
 }
 
-impl From<num::ParseIntError> for ParameterRangeError {
-    fn from(e: num::ParseIntError) -> ParameterRangeError {
-        ParameterRangeError::ParseIntError(e)
+impl From<num::ParseIntError> for ParameterScanError {
+    fn from(e: num::ParseIntError) -> ParameterScanError {
+        ParameterScanError::ParseIntError(e)
     }
 }
 
-impl fmt::Display for ParameterRangeError {
+impl fmt::Display for ParameterScanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.__description())
     }
 }
 
-impl Error for ParameterRangeError {
+impl Error for ParameterScanError {
     fn description(&self) -> &str {
         self.__description()
     }

--- a/src/hyperfine/mod.rs
+++ b/src/hyperfine/mod.rs
@@ -7,3 +7,4 @@ pub mod shell;
 pub mod timer;
 pub mod types;
 pub mod warnings;
+pub mod error;

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -1,8 +1,51 @@
-/// The types module contains common internal types for the application.
-///
+/// This module contains common internal types.
+
+use std::fmt;
 
 /// Type alias for unit of time
 pub type Second = f64;
+
+/// A command that should be benchmarked.
+#[derive(Debug, Clone)]
+pub struct Command<'a> {
+    /// The command that should be executed (without parameter substitution)
+    expression: &'a str,
+
+    /// A possible parameter value.
+    parameter: Option<(&'a str, i32)>,
+}
+
+impl<'a> Command<'a> {
+    pub fn new(expression: &'a str) -> Command<'a> {
+        Command {
+            expression: expression,
+            parameter: None,
+        }
+    }
+
+    pub fn new_parametrized(expression: &'a str, parameter: &'a str, value: i32) -> Command<'a> {
+        Command {
+            expression: expression,
+            parameter: Some((parameter, value)),
+        }
+    }
+
+    pub fn get_shell_command(&self) -> String {
+        match self.parameter {
+            Some((param_name, param_value)) => self.expression.replace(
+                &format!("{{{param_name}}}", param_name = param_name),
+                &param_value.to_string(),
+            ),
+            None => self.expression.into(),
+        }
+    }
+}
+
+impl<'a> fmt::Display for Command<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.get_shell_command())
+    }
+}
 
 /// Action to take when an executed command fails.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ fn main() {
                      string '{VAR}' in each command by the current parameter value.",
                 )
                 .takes_value(true)
+                .allow_hyphen_values(true)
                 .value_names(&["VAR", "MIN", "MAX"]),
         )
         .arg(


### PR DESCRIPTION
A first draft for `--parameter-range`:
```
    -r, --parameter-range <VAR> <MIN> <MAX>
            Perform benchmark runs for each value in the range MIN..MAX. Replaces the
            string '{VAR}' in each command by the current parameter value.
```

It can be used like this:

``` 
> hyperfine --parameter-range time 1 3 'sleep {time}'

Benchmark #1: sleep 1

  Time (mean ± σ):      1.002 s ±  0.001 s    [User: 0.7 ms, System: 2.0 ms]
 
  Range (min … max):    1.001 s …  1.003 s
 
Benchmark #2: sleep 2

  Time (mean ± σ):      2.003 s ±  0.002 s    [User: 1.6 ms, System: 1.8 ms]
 
  Range (min … max):    2.000 s …  2.005 s
 
Benchmark #3: sleep 3

  Time (mean ± σ):      3.002 s ±  0.002 s    [User: 1.5 ms, System: 0.9 ms]
 
  Range (min … max):    3.000 s …  3.005 s

```


@stevepentland f.y.i.