### PR TITLE
[WIP] Add initial support for --shell

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -78,6 +78,17 @@ fn build_app() -> App<'static, 'static> {
                 .value_names(&["VAR", "MIN", "MAX"]),
         )
         .arg(
+            Arg::with_name("shell")
+                .long("shell")
+                .short("S")
+                .takes_value(true)
+                .value_name("SHELL")
+                .help(
+                    "Specifies the shell environment to set up under which the benchmarked \
+                     commands will bexe executed.",
+                )
+        )
+        .arg(
             Arg::with_name("style")
                 .long("style")
                 .short("s")

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -37,13 +37,14 @@ fn subtract_shell_spawning_time(time: Second, shell_spawning_time: Second) -> Se
 
 /// Run the given shell command and measure the execution time
 pub fn time_shell_command(
+    shell: &str,
     command: &Command,
     failure_action: CmdFailureAction,
     shell_spawning_time: Option<TimingResult>,
 ) -> io::Result<(TimingResult, bool)> {
     let wallclock_timer = WallClockTimer::start();
 
-    let result = execute_and_time(&command.get_shell_command())?;
+    let result = execute_and_time(shell, &command.get_shell_command())?;
 
     let mut time_user = result.user_time;
     let mut time_system = result.system_time;
@@ -76,7 +77,7 @@ pub fn time_shell_command(
 }
 
 /// Measure the average shell spawning time
-pub fn mean_shell_spawning_time(style: &OutputStyleOption) -> io::Result<TimingResult> {
+pub fn mean_shell_spawning_time(shell: &str, style: &OutputStyleOption) -> io::Result<TimingResult> {
     const COUNT: u64 = 200;
     let progress_bar = get_progress_bar(COUNT, "Measuring shell spawning time", style);
 
@@ -86,7 +87,7 @@ pub fn mean_shell_spawning_time(style: &OutputStyleOption) -> io::Result<TimingR
 
     for _ in 0..COUNT {
         // Just run the shell without any command
-        let res = time_shell_command(&Command::new(""), CmdFailureAction::RaiseError, None);
+        let res = time_shell_command(shell, &Command::new(""), CmdFailureAction::RaiseError, None);
 
         match res {
             Err(_) => {
@@ -114,9 +115,10 @@ pub fn mean_shell_spawning_time(style: &OutputStyleOption) -> io::Result<TimingR
 }
 
 /// Run the command specified by `--prepare`.
-fn run_preparation_command(command: &Option<String>) -> io::Result<TimingResult> {
+fn run_preparation_command(shell: &str, command: &Option<String>) -> io::Result<TimingResult> {
     if let &Some(ref preparation_command) = command {
         let res = time_shell_command(
+            shell,
             &Command::new(preparation_command),
             CmdFailureAction::RaiseError,
             None,
@@ -164,7 +166,7 @@ pub fn run_benchmark(
         );
 
         for _ in 0..options.warmup_count {
-            let _ = time_shell_command(cmd, options.failure_action, None)?;
+            let _ = time_shell_command(&options.shell, cmd, options.failure_action, None)?;
             progress_bar.inc(1);
         }
         progress_bar.finish_and_clear();
@@ -178,11 +180,11 @@ pub fn run_benchmark(
     );
 
     // Run init / cleanup command
-    let prepare_res = run_preparation_command(&options.preparation_command)?;
+    let prepare_res = run_preparation_command(&options.shell, &options.preparation_command)?;
 
     // Initial timing run
     let (res, success) =
-        time_shell_command(cmd, options.failure_action, Some(shell_spawning_time))?;
+        time_shell_command(&options.shell, cmd, options.failure_action, Some(shell_spawning_time))?;
 
     // Determine number of benchmark runs
     let runs_in_min_time = (options.min_time_sec
@@ -209,7 +211,7 @@ pub fn run_benchmark(
 
     // Gather statistics
     for _ in 0..count_remaining {
-        run_preparation_command(&options.preparation_command)?;
+        run_preparation_command(&options.shell, &options.preparation_command)?;
 
         let msg = {
             let mean = format_duration(mean(&times_real), None);
@@ -218,7 +220,7 @@ pub fn run_benchmark(
         progress_bar.set_message(&msg);
 
         let (res, success) =
-            time_shell_command(cmd, options.failure_action, Some(shell_spawning_time))?;
+            time_shell_command(&options.shell, cmd, options.failure_action, Some(shell_spawning_time))?;
 
         times_real.push(res.time_real);
         times_user.push(res.time_user);

--- a/src/hyperfine/shell.rs
+++ b/src/hyperfine/shell.rs
@@ -34,10 +34,10 @@ pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
 
 /// Execute the given command and return a timing summary
 #[cfg(not(windows))]
-pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
+pub fn execute_and_time(shell: &str, command: &str) -> io::Result<ExecuteResult> {
     let cpu_timer = get_cpu_timer();
 
-    let status = run_shell_command(command)?;
+    let status = run_shell_command(shell, command)?;
 
     let (user_time, system_time) = cpu_timer.stop();
 
@@ -50,8 +50,8 @@ pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
 
 /// Run a standard shell command
 #[cfg(not(windows))]
-fn run_shell_command(command: &str) -> io::Result<std::process::ExitStatus> {
-    Command::new("sh")
+fn run_shell_command(shell: &str, command: &str) -> io::Result<std::process::ExitStatus> {
+    Command::new(shell)
         .arg("-c")
         .arg(command)
         .stdin(Stdio::null())
@@ -62,7 +62,7 @@ fn run_shell_command(command: &str) -> io::Result<std::process::ExitStatus> {
 
 /// Run a Windows shell command using cmd.exe
 #[cfg(windows)]
-fn run_shell_command(command: &str) -> io::Result<std::process::Child> {
+fn run_shell_command(_: &str, command: &str) -> io::Result<std::process::Child> {
     Command::new("cmd")
         .arg("/C")
         .arg(command)

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -87,6 +87,9 @@ pub struct HyperfineOptions {
     /// Command to run before each timing run
     pub preparation_command: Option<String>,
 
+    /// Shell under which commands should be run
+    pub shell: String,
+
     /// What color mode to use for output
     pub output_style: OutputStyleOption,
 }
@@ -100,6 +103,7 @@ impl Default for HyperfineOptions {
             failure_action: CmdFailureAction::RaiseError,
             preparation_command: None,
             output_style: OutputStyleOption::Full,
+            shell: "sh".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ pub fn error(message: &str) -> ! {
 
 /// Runs the benchmark for the given commands
 fn run(commands: &Vec<Command>, options: &HyperfineOptions) -> io::Result<Vec<BenchmarkResult>> {
-    let shell_spawning_time = mean_shell_spawning_time(&options.output_style)?;
+    let shell_spawning_time = mean_shell_spawning_time(&options.shell, &options.output_style)?;
 
     let mut timing_results = vec![];
 
@@ -120,6 +120,7 @@ fn build_hyperfine_options(matches: &ArgMatches) -> HyperfineOptions {
         .value_of("warmup")
         .and_then(&str_to_u64)
         .unwrap_or(0);
+    options.shell = get_shell(matches).to_string();
 
     if let Some(min_runs) = matches.value_of("min-runs").and_then(&str_to_u64) {
         // we need at least two runs to compute a variance
@@ -169,6 +170,12 @@ fn build_export_manager(matches: &ArgMatches) -> ExportManager {
         export_manager.add_exporter(ExportType::Markdown, filename);
     }
     export_manager
+}
+
+/// Retrieve shell parameter or set default
+fn get_shell<'a>(matches: &'a ArgMatches) -> &'a str {
+    matches.value_of("shell")
+        .unwrap_or("sh")
 }
 
 /// Build the commands to benchmark


### PR DESCRIPTION
I thought the options array would be exposed/cloned/passed-around much
more than it actually was; ended up having to pass around a shell
parameter separately to get it to where it needed to be.

What's missing is some paradigm for setting the "default" shell, since I
don't think aliasing `hyperfine` to `hyperfine -S fish` would support
`hyperfine -s sh` for a one-off non-fish benchmark, as I think clap
doesn't handle specifying a command twice to override the first
argument.

`--shell foo` or `-S foo` (`-s` is already taken)