### PR TITLE
Allow forwarding benchmark's stdout to hyperfine

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -119,12 +119,13 @@ fn build_app() -> App<'static, 'static> {
                 .help("Export the timing results as a Markdown table to the given FILE."),
         )
         .arg(
-            Arg::with_name("print-stdout")
-                .long("print-stdout")
+            Arg::with_name("show-output")
+                .long("show-output")
                 .conflicts_with("style")
-                .help("Print the stdout of the benchmark instead of suppressing it. \
+                .help("Print the stdout and stderr of the benchmark instead of suppressing it. \
                        This will increase the time it takes for benchmarks to run, \
-                       so it should only be used when trying to benchmark output speed."),
+                       so it should only be used for debugging purposes or \
+                       when trying to benchmark output speed."),
         )
         .help_message("Print this help message.")
         .version_message("Show version information.")

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -118,6 +118,14 @@ fn build_app() -> App<'static, 'static> {
                 .value_name("FILE")
                 .help("Export the timing results as a Markdown table to the given FILE."),
         )
+        .arg(
+            Arg::with_name("print-stdout")
+                .long("print-stdout")
+                .conflicts_with("style")
+                .help("Print the stdout of the benchmark instead of suppressing it. \
+                       This will increase the time it takes for benchmarks to run, \
+                       so it should only be used when trying to benchmark output speed."),
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.")
 }

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::process::Stdio;
 
 use colored::*;
 use statistical::{mean, standard_deviation};
@@ -38,12 +39,18 @@ fn subtract_shell_spawning_time(time: Second, shell_spawning_time: Second) -> Se
 /// Run the given shell command and measure the execution time
 pub fn time_shell_command(
     command: &Command,
+    print_stdout: bool,
     failure_action: CmdFailureAction,
     shell_spawning_time: Option<TimingResult>,
 ) -> io::Result<(TimingResult, bool)> {
     let wallclock_timer = WallClockTimer::start();
 
-    let result = execute_and_time(&command.get_shell_command())?;
+    let stdout = if print_stdout {
+        Stdio::inherit()
+    } else {
+        Stdio::null()
+    };
+    let result = execute_and_time(stdout, &command.get_shell_command())?;
 
     let mut time_user = result.user_time;
     let mut time_system = result.system_time;
@@ -76,7 +83,10 @@ pub fn time_shell_command(
 }
 
 /// Measure the average shell spawning time
-pub fn mean_shell_spawning_time(style: &OutputStyleOption) -> io::Result<TimingResult> {
+pub fn mean_shell_spawning_time(
+    style: &OutputStyleOption,
+    print_stdout: bool,
+) -> io::Result<TimingResult> {
     const COUNT: u64 = 200;
     let progress_bar = get_progress_bar(COUNT, "Measuring shell spawning time", style);
 
@@ -86,7 +96,12 @@ pub fn mean_shell_spawning_time(style: &OutputStyleOption) -> io::Result<TimingR
 
     for _ in 0..COUNT {
         // Just run the shell without any command
-        let res = time_shell_command(&Command::new(""), CmdFailureAction::RaiseError, None);
+        let res = time_shell_command(
+            &Command::new(""),
+            print_stdout,
+            CmdFailureAction::RaiseError,
+            None,
+        );
 
         match res {
             Err(_) => {
@@ -114,10 +129,14 @@ pub fn mean_shell_spawning_time(style: &OutputStyleOption) -> io::Result<TimingR
 }
 
 /// Run the command specified by `--prepare`.
-fn run_preparation_command(command: &Option<String>) -> io::Result<TimingResult> {
+fn run_preparation_command(
+    command: &Option<String>,
+    print_stdout: bool,
+) -> io::Result<TimingResult> {
     if let &Some(ref preparation_command) = command {
         let res = time_shell_command(
             &Command::new(preparation_command),
+            print_stdout,
             CmdFailureAction::RaiseError,
             None,
         );
@@ -164,7 +183,7 @@ pub fn run_benchmark(
         );
 
         for _ in 0..options.warmup_count {
-            let _ = time_shell_command(cmd, options.failure_action, None)?;
+            let _ = time_shell_command(cmd, options.print_stdout, options.failure_action, None)?;
             progress_bar.inc(1);
         }
         progress_bar.finish_and_clear();
@@ -178,11 +197,15 @@ pub fn run_benchmark(
     );
 
     // Run init / cleanup command
-    let prepare_res = run_preparation_command(&options.preparation_command)?;
+    let prepare_res = run_preparation_command(&options.preparation_command, options.print_stdout)?;
 
     // Initial timing run
-    let (res, success) =
-        time_shell_command(cmd, options.failure_action, Some(shell_spawning_time))?;
+    let (res, success) = time_shell_command(
+        cmd,
+        options.print_stdout,
+        options.failure_action,
+        Some(shell_spawning_time),
+    )?;
 
     // Determine number of benchmark runs
     let runs_in_min_time = (options.min_time_sec
@@ -209,7 +232,7 @@ pub fn run_benchmark(
 
     // Gather statistics
     for _ in 0..count_remaining {
-        run_preparation_command(&options.preparation_command)?;
+        run_preparation_command(&options.preparation_command, options.print_stdout)?;
 
         let msg = {
             let mean = format_duration(mean(&times_real), None);
@@ -217,8 +240,12 @@ pub fn run_benchmark(
         };
         progress_bar.set_message(&msg);
 
-        let (res, success) =
-            time_shell_command(cmd, options.failure_action, Some(shell_spawning_time))?;
+        let (res, success) = time_shell_command(
+            cmd,
+            options.print_stdout,
+            options.failure_action,
+            Some(shell_spawning_time),
+        )?;
 
         times_real.push(res.time_real);
         times_user.push(res.time_user);

--- a/src/hyperfine/shell.rs
+++ b/src/hyperfine/shell.rs
@@ -19,8 +19,8 @@ pub struct ExecuteResult {
 
 /// Execute the given command and return a timing summary
 #[cfg(windows)]
-pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
-    let mut child = run_shell_command(command)?;
+pub fn execute_and_time(stdout: Stdio, command: &str) -> io::Result<ExecuteResult> {
+    let mut child = run_shell_command(stdout, command)?;
     let cpu_timer = get_cpu_timer(&child);
     let status = child.wait()?;
 
@@ -34,10 +34,10 @@ pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
 
 /// Execute the given command and return a timing summary
 #[cfg(not(windows))]
-pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
+pub fn execute_and_time(stdout: Stdio, command: &str) -> io::Result<ExecuteResult> {
     let cpu_timer = get_cpu_timer();
 
-    let status = run_shell_command(command)?;
+    let status = run_shell_command(stdout, command)?;
 
     let (user_time, system_time) = cpu_timer.stop();
 
@@ -50,24 +50,24 @@ pub fn execute_and_time(command: &str) -> io::Result<ExecuteResult> {
 
 /// Run a standard shell command
 #[cfg(not(windows))]
-fn run_shell_command(command: &str) -> io::Result<std::process::ExitStatus> {
+fn run_shell_command(stdout: Stdio, command: &str) -> io::Result<std::process::ExitStatus> {
     Command::new("sh")
         .arg("-c")
         .arg(command)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
+        .stdout(stdout)
         .stderr(Stdio::null())
         .status()
 }
 
 /// Run a Windows shell command using cmd.exe
 #[cfg(windows)]
-fn run_shell_command(command: &str) -> io::Result<std::process::Child> {
+fn run_shell_command(print_stdout: bool, command: &str) -> io::Result<std::process::Child> {
     Command::new("cmd")
         .arg("/C")
         .arg(command)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
+        .stdout(stdout)
         .stderr(Stdio::null())
         .spawn()
 }

--- a/src/hyperfine/shell.rs
+++ b/src/hyperfine/shell.rs
@@ -19,8 +19,8 @@ pub struct ExecuteResult {
 
 /// Execute the given command and return a timing summary
 #[cfg(windows)]
-pub fn execute_and_time(stdout: Stdio, command: &str) -> io::Result<ExecuteResult> {
-    let mut child = run_shell_command(stdout, command)?;
+pub fn execute_and_time(stdout: Stdio, stderr: Stdio, command: &str) -> io::Result<ExecuteResult> {
+    let mut child = run_shell_command(stdout, stderr, command)?;
     let cpu_timer = get_cpu_timer(&child);
     let status = child.wait()?;
 
@@ -34,10 +34,10 @@ pub fn execute_and_time(stdout: Stdio, command: &str) -> io::Result<ExecuteResul
 
 /// Execute the given command and return a timing summary
 #[cfg(not(windows))]
-pub fn execute_and_time(stdout: Stdio, command: &str) -> io::Result<ExecuteResult> {
+pub fn execute_and_time(stdout: Stdio, stderr: Stdio, command: &str) -> io::Result<ExecuteResult> {
     let cpu_timer = get_cpu_timer();
 
-    let status = run_shell_command(stdout, command)?;
+    let status = run_shell_command(stdout, stderr, command)?;
 
     let (user_time, system_time) = cpu_timer.stop();
 
@@ -50,24 +50,24 @@ pub fn execute_and_time(stdout: Stdio, command: &str) -> io::Result<ExecuteResul
 
 /// Run a standard shell command
 #[cfg(not(windows))]
-fn run_shell_command(stdout: Stdio, command: &str) -> io::Result<std::process::ExitStatus> {
+fn run_shell_command(stdout: Stdio, stderr: Stdio, command: &str) -> io::Result<std::process::ExitStatus> {
     Command::new("sh")
         .arg("-c")
         .arg(command)
         .stdin(Stdio::null())
         .stdout(stdout)
-        .stderr(Stdio::null())
+        .stderr(stderr)
         .status()
 }
 
 /// Run a Windows shell command using cmd.exe
 #[cfg(windows)]
-fn run_shell_command(stdout: Stdio, command: &str) -> io::Result<std::process::Child> {
+fn run_shell_command(stdout: Stdio, stderr: Stdio, command: &str) -> io::Result<std::process::Child> {
     Command::new("cmd")
         .arg("/C")
         .arg(command)
         .stdin(Stdio::null())
         .stdout(stdout)
-        .stderr(Stdio::null())
+        .stderr(stderr)
         .spawn()
 }

--- a/src/hyperfine/shell.rs
+++ b/src/hyperfine/shell.rs
@@ -62,7 +62,7 @@ fn run_shell_command(stdout: Stdio, command: &str) -> io::Result<std::process::E
 
 /// Run a Windows shell command using cmd.exe
 #[cfg(windows)]
-fn run_shell_command(print_stdout: bool, command: &str) -> io::Result<std::process::Child> {
+fn run_shell_command(stdout: Stdio, command: &str) -> io::Result<std::process::Child> {
     Command::new("cmd")
         .arg("/C")
         .arg(command)

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -91,7 +91,7 @@ pub struct HyperfineOptions {
     pub output_style: OutputStyleOption,
 
     /// Forward benchmark's stdout to hyperfine's stdout
-    pub print_stdout: bool,
+    pub show_output: bool,
 }
 
 impl Default for HyperfineOptions {
@@ -103,7 +103,7 @@ impl Default for HyperfineOptions {
             failure_action: CmdFailureAction::RaiseError,
             preparation_command: None,
             output_style: OutputStyleOption::Full,
-            print_stdout: false,
+            show_output: false,
         }
     }
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -89,6 +89,9 @@ pub struct HyperfineOptions {
 
     /// What color mode to use for output
     pub output_style: OutputStyleOption,
+
+    /// Forward benchmark's stdout to hyperfine's stdout
+    pub print_stdout: bool,
 }
 
 impl Default for HyperfineOptions {
@@ -100,6 +103,7 @@ impl Default for HyperfineOptions {
             failure_action: CmdFailureAction::RaiseError,
             preparation_command: None,
             output_style: OutputStyleOption::Full,
+            print_stdout: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ pub fn error(message: &str) -> ! {
 /// Runs the benchmark for the given commands
 fn run(commands: &Vec<Command>, options: &HyperfineOptions) -> io::Result<Vec<BenchmarkResult>> {
     let shell_spawning_time =
-        mean_shell_spawning_time(&options.output_style, options.print_stdout)?;
+        mean_shell_spawning_time(&options.output_style, options.show_output)?;
 
     let mut timing_results = vec![];
 
@@ -129,13 +129,13 @@ fn build_hyperfine_options(matches: &ArgMatches) -> HyperfineOptions {
 
     options.preparation_command = matches.value_of("prepare").map(String::from);
 
-    options.print_stdout = matches.is_present("print-stdout");
+    options.show_output = matches.is_present("show-output");
 
     options.output_style = match matches.value_of("style") {
         Some("full") => OutputStyleOption::Full,
         Some("basic") => OutputStyleOption::Basic,
         Some("nocolor") => OutputStyleOption::NoColor,
-        _ => if !options.print_stdout && atty::is(Stream::Stdout) {
+        _ => if !options.show_output && atty::is(Stream::Stdout) {
             OutputStyleOption::Full
         } else {
             OutputStyleOption::Basic

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,8 @@ pub fn error(message: &str) -> ! {
 
 /// Runs the benchmark for the given commands
 fn run(commands: &Vec<Command>, options: &HyperfineOptions) -> io::Result<Vec<BenchmarkResult>> {
-    let shell_spawning_time = mean_shell_spawning_time(&options.output_style)?;
+    let shell_spawning_time =
+        mean_shell_spawning_time(&options.output_style, options.print_stdout)?;
 
     let mut timing_results = vec![];
 
@@ -128,11 +129,13 @@ fn build_hyperfine_options(matches: &ArgMatches) -> HyperfineOptions {
 
     options.preparation_command = matches.value_of("prepare").map(String::from);
 
+    options.print_stdout = matches.is_present("print-stdout");
+
     options.output_style = match matches.value_of("style") {
         Some("full") => OutputStyleOption::Full,
         Some("basic") => OutputStyleOption::Basic,
         Some("nocolor") => OutputStyleOption::NoColor,
-        _ => if atty::is(Stream::Stdout) {
+        _ => if !options.print_stdout && atty::is(Stream::Stdout) {
             OutputStyleOption::Full
         } else {
             OutputStyleOption::Basic


### PR DESCRIPTION
This change makes it possible to forward the stdout of the command the
user tries to benchmark to hyperfine's stdout using the `--print-stdout`
flag.

This should be irrelevant for most use-cases, however it makes it
possible to get some crude benchmarks of terminal emulators similar to
what's currently often done with `time cat file`.

I'm not quite sure if this is a desired feature for hyperfine because it's
probably not gonna be required by most users. But since I need it for my
personal usecase anyways, I thought I might as well send a PR.