### PR TITLE
change windows cmd interpreter

### DIFF
--- a/src/hyperfine/shell.rs
+++ b/src/hyperfine/shell.rs
@@ -71,7 +71,7 @@ fn run_shell_command(
     stderr: Stdio,
     command: &str,
 ) -> io::Result<std::process::Child> {
-    Command::new("cmd")
+    Command::new("cmd.exe")
         .arg("/C")
         .arg(command)
         .stdin(Stdio::null())


### PR DESCRIPTION
The default command line interpreter of Windows is `cmd.exe`, moreover the order in which a file is selected to run [depends](https://stackoverflow.com/questions/605101/order-in-which-command-prompt-executes-files-with-the-same-name-a-bat-vs-a-cmd) also on its extension, for example in my machine:

```
$ echo %PATHEXT%
.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
```
so if there is a file named `cmd.com` in %PATH% then it will be selected to run instead of `cmd.exe`.