### PR TITLE
Change markdown export to use seconds, closes #71

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -55,6 +55,22 @@ fn build_app() -> App<'static, 'static> {
                 .help("Perform at least NUM runs for each command (default: 10)."),
         )
         .arg(
+            Arg::with_name("max-runs")
+                .long("max-runs")
+                .short("M")
+                .takes_value(true)
+                .value_name("NUM")
+                .help("Perform at most NUM runs for each command."),
+        )
+        .arg(
+            Arg::with_name("runs")
+                .long("runs")
+                .short("r")
+                .takes_value(true)
+                .value_name("NUM")
+                .help("Perform exactly NUM runs for each command."),
+        )
+        .arg(
             Arg::with_name("prepare")
                 .long("prepare")
                 .short("p")

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -65,6 +65,7 @@ fn build_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name("runs")
                 .long("runs")
+                .conflicts_with_all(&["max-runs", "min-runs"])
                 .short("r")
                 .takes_value(true)
                 .value_name("NUM")

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -216,10 +216,13 @@ pub fn run_benchmark(
         / (res.time_real + prepare_res.time_real + shell_spawning_time.time_real))
         as u64;
 
-    let count = cmp::min(
-        cmp::max(runs_in_min_time, options.runs.min),
-        options.runs.max
-    );
+    let count = {
+        let min = cmp::max(runs_in_min_time, options.runs.min);
+
+        options.runs.max.as_ref()
+            .map(|max| cmp::min(min, *max))
+            .unwrap_or(min)
+    };
 
     let count_remaining = count - 1;
 

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::io;
 use std::process::Stdio;
 
@@ -187,7 +188,7 @@ pub fn run_benchmark(
 
     // Set up progress bar (and spinner for initial measurement)
     let progress_bar = get_progress_bar(
-        options.min_runs,
+        options.runs.min,
         "Initial time measurement",
         &options.output_style,
     );
@@ -215,11 +216,10 @@ pub fn run_benchmark(
         / (res.time_real + prepare_res.time_real + shell_spawning_time.time_real))
         as u64;
 
-    let count = if runs_in_min_time >= options.min_runs {
-        runs_in_min_time
-    } else {
-        options.min_runs
-    };
+    let count = cmp::min(
+        cmp::max(runs_in_min_time, options.runs.min),
+        options.runs.max
+    );
 
     let count_remaining = count - 1;
 

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -9,16 +9,6 @@ pub enum ParameterScanError {
     TooLarge,
 }
 
-impl ParameterScanError {
-    fn __description(&self) -> &str {
-        match *self {
-            ParameterScanError::ParseIntError(ref e) => e.description(),
-            ParameterScanError::EmptyRange => "Empty parameter range",
-            ParameterScanError::TooLarge => "Parameter range is too large",
-        }
-    }
-}
-
 impl From<num::ParseIntError> for ParameterScanError {
     fn from(e: num::ParseIntError) -> ParameterScanError {
         ParameterScanError::ParseIntError(e)
@@ -27,12 +17,37 @@ impl From<num::ParseIntError> for ParameterScanError {
 
 impl fmt::Display for ParameterScanError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.__description())
+        write!(f, "{}", self.description())
     }
 }
 
 impl Error for ParameterScanError {
     fn description(&self) -> &str {
-        self.__description()
+        match *self {
+            ParameterScanError::ParseIntError(ref e) => e.description(),
+            ParameterScanError::EmptyRange => "Empty parameter range",
+            ParameterScanError::TooLarge => "Parameter range is too large",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum OptionsError {
+    RunsBelowTwo,
+    EmptyRunsRange,
+}
+
+impl fmt::Display for OptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl Error for OptionsError {
+    fn description(&self) -> &str {
+        match *self {
+            OptionsError::EmptyRunsRange => "Empty runs range",
+            OptionsError::RunsBelowTwo => "Number of runs below two",
+        }
     }
 }

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -1,39 +1,157 @@
 use super::Exporter;
+
+use hyperfine::format::{Unit, format_duration_value};
 use hyperfine::types::BenchmarkResult;
 
 use std::io::Result;
 
-const MULTIPLIER: f64 = 1e3;
+macro_rules! TABLE_HEADER {
+    ($unit:expr) => {
+        format!("| Command | Mean [{unit}] | Min…Max [{unit}] |\n|:---|---:|---:|\n", unit=$unit) };
+}
 
 #[derive(Default)]
 pub struct MarkdownExporter {}
 
 impl Exporter for MarkdownExporter {
     fn serialize(&self, results: &Vec<BenchmarkResult>) -> Result<Vec<u8>> {
-        let mut destination = start_table();
+        // Default to `Second`.
+        let mut unit = Unit::Second;
+
+        if !results.is_empty() {
+            // Use the first BenchmarkResult entry to determine the unit for all entries.
+            unit = format_duration_value(results[0].mean, None).1;
+        }
+
+        let mut destination = start_table(unit);
 
         for result in results {
-            add_table_row(&mut destination, result);
+            add_table_row(&mut destination, result, unit);
         }
 
         Ok(destination)
     }
 }
 
-fn start_table() -> Vec<u8> {
-    "| Command | Mean [ms] | Min…Max [ms] |\n|:---|---:|---:|\n"
-        .bytes()
-        .collect()
+fn start_table(unit: Unit) -> Vec<u8> {
+    TABLE_HEADER!(unit.short_name()).bytes().collect()
 }
-fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResult) {
+
+fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResult, unit: Unit) {
+    let mean_str = format_duration_value(entry.mean, Some(unit)).0;
+    let stddev_str = format_duration_value(entry.stddev, Some(unit)).0;
+    let min_str = format_duration_value(entry.min, Some(unit)).0;
+    let max_str = format_duration_value(entry.max, Some(unit)).0;
+
     dest.extend(
         format!(
-            "| `{}` | {:.1} ± {:.1} | {:.1}…{:.1} |\n",
-            entry.command.replace("|", "\\|"),
-            entry.mean * MULTIPLIER,
-            entry.stddev * MULTIPLIER,
-            entry.min * MULTIPLIER,
-            entry.max * MULTIPLIER
+            "| `{command}` | {mean} ± {stddev} | {min}…{max} |\n",
+            command=entry.command.replace("|", "\\|"),
+            mean=mean_str,
+            stddev=stddev_str,
+            min=min_str,
+            max=max_str,
         ).as_bytes(),
     );
+}
+
+/// Ensure the markdown output includes the table header and the multiple
+/// benchmark results as a table. The list of actual times is not included
+/// in the output.
+///
+/// This also demonstrates that the first entry's units (ms) are used to set
+/// the units for all entries.
+#[test]
+fn test_markdown_format_ms() {
+    let exporter = MarkdownExporter::default();
+
+    let mut timing_results = vec![];
+
+    timing_results.push(BenchmarkResult::new(
+            String::from("sleep 0.1"),
+            0.1057, // mean
+            0.0016, // std dev
+            0.0009, // user_mean
+            0.0011, // system_mean
+            0.1023, // min
+            0.1080, // max
+            vec![0.1, 0.1, 0.1], // times
+            ));
+
+    timing_results.push(BenchmarkResult::new(
+            String::from("sleep 2"),
+            2.0050, // mean
+            0.0020, // std dev
+            0.0009, // user_mean
+            0.0012, // system_mean
+            2.0020, // min
+            2.0080, // max
+            vec![2.0, 2.0, 2.0], // times
+            ));
+
+    let formatted = String::from_utf8(exporter.serialize(&timing_results).unwrap()).unwrap();
+
+    let formatted_expected = format!(
+"{}\
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 |
+", TABLE_HEADER!("ms"));
+
+    assert_eq!(formatted_expected, formatted);
+}
+
+/// This (again) demonstrates that the first entry's units (s) are used to set
+/// the units for all entries.
+#[test]
+fn test_markdown_format_s() {
+    let exporter = MarkdownExporter::default();
+
+    let mut timing_results = vec![];
+
+    timing_results.push(BenchmarkResult::new(
+            String::from("sleep 2"),
+            2.0050, // mean
+            0.0020, // std dev
+            0.0009, // user_mean
+            0.0012, // system_mean
+            2.0020, // min
+            2.0080, // max
+            vec![2.0, 2.0, 2.0], // times
+            ));
+
+    timing_results.push(BenchmarkResult::new(
+            String::from("sleep 0.1"),
+            0.1057, // mean
+            0.0016, // std dev
+            0.0009, // user_mean
+            0.0011, // system_mean
+            0.1023, // min
+            0.1080, // max
+            vec![0.1, 0.1, 0.1], // times
+            ));
+
+    let formatted = String::from_utf8(exporter.serialize(&timing_results).unwrap()).unwrap();
+
+    let formatted_expected = format!(
+"{}\
+| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 |
+", TABLE_HEADER!("s"));
+
+    assert_eq!(formatted_expected, formatted);
+}
+
+/// An empty list of benchmark results will only include the table header
+/// in the markdown output, using the default `Seconds` unit.
+#[test]
+fn test_markdown_format_empty_results() {
+    let exporter = MarkdownExporter::default();
+
+    let timing_results = vec![];
+
+    let formatted = String::from_utf8(exporter.serialize(&timing_results).unwrap()).unwrap();
+
+    let formatted_expected = TABLE_HEADER!("s");
+
+    assert_eq!(formatted_expected, formatted);
 }

--- a/src/hyperfine/format.rs
+++ b/src/hyperfine/format.rs
@@ -6,6 +6,34 @@ pub enum Unit {
     MilliSecond,
 }
 
+impl Unit {
+    /// The abbreviation of the Unit.
+    pub fn short_name(&self) -> String {
+        match *self {
+            Unit::Second => String::from("s"),
+            Unit::MilliSecond => String::from("ms"),
+        }
+    }
+
+    /// The multiplier value to convert from `from_unit` to the Unit.
+    pub fn multiplier_from(&self, from_unit: Unit) -> f64 {
+        match (*self, from_unit) {
+            (Unit::Second, Unit::Second) => 1.0,
+            (Unit::MilliSecond, Unit::MilliSecond) => 1.0,
+            (Unit::Second, Unit::MilliSecond) => 1e-3,
+            (Unit::MilliSecond, Unit::Second) => 1e3,
+        }
+    }
+
+    /// Returns the Second value formatted for the Unit.
+    pub fn format(&self, value: Second) -> String {
+        match *self {
+            Unit::Second => format!("{:.3}", value * self.multiplier_from(Unit::Second)),
+            Unit::MilliSecond => format!("{:.1}", value * self.multiplier_from(Unit::Second)),
+        }
+    }
+}
+
 /// Format the given duration as a string. The output-unit can be enforced by setting `unit` to
 /// `Some(target_unit)`. If `unit` is `None`, it will be determined automatically.
 pub fn format_duration(duration: Second, unit: Option<Unit>) -> String {
@@ -16,11 +44,54 @@ pub fn format_duration(duration: Second, unit: Option<Unit>) -> String {
 
 /// Like `format_duration`, but returns the target unit as well.
 pub fn format_duration_unit(duration: Second, unit: Option<Unit>) -> (String, Unit) {
-    if (duration < 1.0 && unit.is_none()) || unit == Some(Unit::MilliSecond) {
-        (format!("{:.1} ms", duration * 1e3), Unit::MilliSecond)
-    } else {
-        (format!("{:.3} s", duration), Unit::Second)
+    let (out_str, out_unit) = format_duration_value(duration, unit);
+
+    (format!("{} {}", out_str, out_unit.short_name()), out_unit)
+}
+
+/// Like `format_duration`, but returns the target unit as well.
+pub fn format_duration_value(duration: Second, unit: Option<Unit>) -> (String, Unit) {
+
+    // Default to `Second` until proven otherwise.
+    let mut duration_unit = Unit::Second;
+
+    match unit {
+        Some(unit_option) => {
+            // Use user-supplied unit.
+            duration_unit = unit_option;
+        },
+        None => {
+            if duration < 1.0 {
+                // It's a small value, use `Millisecond` instead.
+                duration_unit = Unit::MilliSecond;
+            }
+        },
     }
+
+    (duration_unit.format(duration), duration_unit)
+}
+
+#[test]
+fn test_unit_short_name() {
+    assert_eq!("s", Unit::Second.short_name());
+    assert_eq!("ms", Unit::MilliSecond.short_name());
+}
+
+#[test]
+fn test_unit_multiplier_from() {
+    assert_eq!(1.0, Unit::Second.multiplier_from(Unit::Second));
+    assert_eq!(1.0, Unit::MilliSecond.multiplier_from(Unit::MilliSecond));
+
+    assert_eq!(0.001, Unit::Second.multiplier_from(Unit::MilliSecond));
+    assert_eq!(1000.0, Unit::MilliSecond.multiplier_from(Unit::Second));
+}
+
+// Note - the values are rounded when formatted.
+#[test]
+fn test_unit_format() {
+    let value: Second = 123.456789;
+    assert_eq!("123.457", Unit::Second.format(value));
+    assert_eq!("123456.8", Unit::MilliSecond.format(value));
 }
 
 #[test]

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -79,14 +79,14 @@ pub struct Runs {
     pub min: u64,
 
     /// Maximum number of benchmark runs
-    pub max: u64,
+    pub max: Option<u64>,
 }
 
 impl Default for Runs {
     fn default() -> Runs {
         Runs {
             min: 10,
-            max: ::std::u64::MAX,
+            max: None,
         }
     }
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -73,13 +73,31 @@ pub enum OutputStyleOption {
     NoColor,
 }
 
+/// Number of runs for a benchmark
+pub struct Runs {
+    /// Minimum number of benchmark runs
+    pub min: u64,
+
+    /// Maximum number of benchmark runs
+    pub max: u64,
+}
+
+impl Default for Runs {
+    fn default() -> Runs {
+        Runs {
+            min: 10,
+            max: ::std::u64::MAX,
+        }
+    }
+}
+
 /// A set of options for hyperfine
 pub struct HyperfineOptions {
     /// Number of warmup runs
     pub warmup_count: u64,
 
-    /// Minimum number of benchmark runs
-    pub min_runs: u64,
+    /// Number of benchmark runs
+    pub runs: Runs,
 
     /// Minimum benchmarking time
     pub min_time_sec: Second,
@@ -101,7 +119,7 @@ impl Default for HyperfineOptions {
     fn default() -> HyperfineOptions {
         HyperfineOptions {
             warmup_count: 0,
-            min_runs: 10,
+            runs: Runs::default(),
             min_time_sec: 3.0,
             failure_action: CmdFailureAction::RaiseError,
             preparation_command: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,14 +148,14 @@ fn build_hyperfine_options(matches: &ArgMatches) -> Result<HyperfineOptions, Opt
         (None, Some(max)) => {
             // Since the minimum was not explicit we lower it if max is below the default min.
             options.runs.min = cmp::min(options.runs.min, max);
-            options.runs.max = max;
+            options.runs.max = Some(max);
         }
         (Some(min), Some(max)) if min > max => {
             return Err(OptionsError::EmptyRunsRange);
         }
         (Some(min), Some(max)) => {
             options.runs.min = min;
-            options.runs.max = max;
+            options.runs.max = Some(max);
         }
         (None, None) => {}
     };


### PR DESCRIPTION
The markdown results exporter was using milliseconds, but the other
results exporters are using the default seconds unit.

* Change the markdown results exporter to also use the default seconds
unit of `BenchmarkResult`.

*This will change the markdown results for all users from milliseconds
to seconds, a UX breaking change.*

* Add unit tests for the markdown exporter to verify the output.

Issue #80 proposes a new option to choose the units used for both the
CLI report and results export.