### PR TITLE
Report standard deviation of the speedup ratio

### DIFF
--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -73,8 +73,8 @@ pub fn write_benchmark_comparison(results: &Vec<BenchmarkResult>) {
         // Covariance asssumed to be 0, i.e. variables are assumed to be independent
         let ratio_stddev = ratio * ( (item.stddev/item.mean).powi(2) + (fastest_item.stddev/fastest_item.mean).powi(2) ).sqrt();
         println!(
-            "{} ± {} faster than '{}'",
-            format!("{:8.2}x", ratio)
+            "{} ± {} times faster than '{}'",
+            format!("{:8.2}", ratio)
                 .bold()
                 .green(),
             format!("{:.2}", ratio_stddev).green(),

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -68,11 +68,16 @@ pub fn write_benchmark_comparison(results: &Vec<BenchmarkResult>) {
     longer_items.sort_by(|l, r| l.mean.partial_cmp(&r.mean).unwrap_or(Ordering::Equal));
 
     for item in longer_items {
+        let ratio = item.mean / fastest_item.mean;
+        // https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
+        // Covariance asssumed to be 0, i.e. variables are assumed to be independent
+        let ratio_stddev = ratio * ( (item.stddev/item.mean).powi(2) + (fastest_item.stddev/fastest_item.mean).powi(2) ).sqrt();
         println!(
-            "{} faster than '{}'",
-            format!("{:8.2}x", item.mean / fastest_item.mean)
+            "{} ± {} faster than '{}'",
+            format!("{:8.2}x", ratio)
                 .bold()
                 .green(),
+            format!("{:.2}", ratio_stddev).green(),
             &item.command.magenta()
         );
     }


### PR DESCRIPTION
Report standard deviation of the speedup ratio.

Here are results for running the same Rust binary that exits immediately twice:

Before:
```
  'target/release/examples/decode' ran
    1.03x faster than 'target/release/examples/decode'
```

After:
```
  'target/release/examples/decode' ran
    1.03x ± 0.65 faster than 'target/release/examples/decode'
```

Results from a real-world benchmarking run:

```
  'flac -fd testsamples/extra/*.flac' ran
    1.56x ± 0.08 faster than 'target/release/examples/decode testsamples/extra/*.flac'
```

I'd also really like to see statistical significance estimation and getting rid of the word "faster" and all that green in case it's not, but I don't have the time to work on it right now.