### PR TITLE
Compact output, add `-s color` option, closes #70

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -100,12 +100,13 @@ fn build_app() -> App<'static, 'static> {
                 .short("s")
                 .takes_value(true)
                 .value_name("TYPE")
-                .possible_values(&["auto", "basic", "full", "nocolor"])
+                .possible_values(&["auto", "basic", "full", "nocolor", "color"])
                 .help(
                     "Set output style type (default: auto). Set this to 'basic' to disable output \
                      coloring and interactive elements. Set it to 'full' to enable all effects \
                      even if no interactive terminal was detected. Set this to 'nocolor' to \
-                     keep the interactive output without any colors.",
+                     keep the interactive output without any colors. Set this to 'color to' keep \
+                     the colors without any interactive output.",
                 ),
         )
         .arg(

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -164,7 +164,6 @@ pub fn run_benchmark(
         (num + 1).to_string().bold(),
         cmd
     );
-    println!();
 
     let mut times_real: Vec<Second> = vec![];
     let mut times_user: Vec<Second> = vec![];
@@ -293,7 +292,6 @@ pub fn run_benchmark(
         user_str.blue(),
         system_str.blue()
     );
-    println!(" ");
 
     println!(
         "  Range ({} … {}):   {:>8} … {:>8}",

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -15,7 +15,7 @@ pub fn get_progress_bar(length: u64, msg: &str, option: &OutputStyleOption) -> P
         OutputStyleOption::Basic | OutputStyleOption::Color => ProgressStyle::default_bar(),
         _ => ProgressStyle::default_spinner()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-            .template("\n {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
+            .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
     };
 
     let progress_bar = match *option {

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -12,14 +12,14 @@ pub const MIN_EXECUTION_TIME: Second = 5e-3;
 /// Return a pre-configured progress bar
 pub fn get_progress_bar(length: u64, msg: &str, option: &OutputStyleOption) -> ProgressBar {
     let progressbar_style = match *option {
-        OutputStyleOption::Basic => ProgressStyle::default_bar(),
+        OutputStyleOption::Basic | OutputStyleOption::Color => ProgressStyle::default_bar(),
         _ => ProgressStyle::default_spinner()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-            .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
+            .template("\n {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
     };
 
     let progress_bar = match *option {
-        OutputStyleOption::Basic => ProgressBar::hidden(),
+        OutputStyleOption::Basic | OutputStyleOption::Color => ProgressBar::hidden(),
         _ => ProgressBar::new(length),
     };
     progress_bar.set_style(progressbar_style.clone());
@@ -63,7 +63,7 @@ pub fn write_benchmark_comparison(results: &Vec<BenchmarkResult>) {
         }
     }
 
-    println!("{}\n", "Summary".bold());
+    println!("{}", "Summary".bold());
     println!("  '{}' ran", fastest_item.command.cyan());
     longer_items.sort_by(|l, r| l.mean.partial_cmp(&r.mean).unwrap_or(Ordering::Equal));
 

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -71,6 +71,9 @@ pub enum OutputStyleOption {
 
     /// Keep elements such as progress bar, but use no coloring
     NoColor,
+
+    /// Keep coloring, but use no progress bar
+    Color,
 }
 
 /// Number of runs for a benchmark

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,8 +184,10 @@ fn build_hyperfine_options(matches: &ArgMatches) -> Result<HyperfineOptions, Opt
     }
 
     match options.output_style {
-        OutputStyleOption::Full | OutputStyleOption::Color => colored::control::unset_override(),
-        _ => colored::control::set_override(false),
+        OutputStyleOption::Basic | OutputStyleOption::NoColor => {
+            colored::control::set_override(false)
+        }
+        _ => {}
     }
 
     if matches.is_present("ignore-failure") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,7 @@ fn build_hyperfine_options(matches: &ArgMatches) -> Result<HyperfineOptions, Opt
         Some("full") => OutputStyleOption::Full,
         Some("basic") => OutputStyleOption::Basic,
         Some("nocolor") => OutputStyleOption::NoColor,
+        Some("color") => OutputStyleOption::Color,
         _ => {
             if !options.show_output && atty::is(Stream::Stdout) {
                 OutputStyleOption::Full
@@ -182,8 +183,9 @@ fn build_hyperfine_options(matches: &ArgMatches) -> Result<HyperfineOptions, Opt
         options.output_style = OutputStyleOption::NoColor;
     }
 
-    if options.output_style != OutputStyleOption::Full {
-        colored::control::set_override(false);
+    match options.output_style {
+        OutputStyleOption::Full | OutputStyleOption::Color => colored::control::unset_override(),
+        _ => colored::control::set_override(false),
     }
 
     if matches.is_present("ignore-failure") {


### PR DESCRIPTION
Strip the empty lines within the results for each benchmark, but keep
the empty line between each benchmark, and before the summary.

Add `color` style option to show color but not be interactive (no
progress bar).