### PR TITLE
Add option to set time units for CLI & Markdown, closes #80

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -86,13 +86,13 @@ fn build_app() -> App<'static, 'static> {
             Arg::with_name("parameter-scan")
                 .long("parameter-scan")
                 .short("P")
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .value_names(&["VAR", "MIN", "MAX"])
                 .help(
                     "Perform benchmark runs for each value in the range MIN..MAX. Replaces the \
                      string '{VAR}' in each command by the current parameter value.",
-                )
-                .takes_value(true)
-                .allow_hyphen_values(true)
-                .value_names(&["VAR", "MIN", "MAX"]),
+                ),
         )
         .arg(
             Arg::with_name("style")
@@ -123,6 +123,16 @@ fn build_app() -> App<'static, 'static> {
                 .long("ignore-failure")
                 .short("i")
                 .help("Ignore non-zero exit codes."),
+        )
+        .arg(
+            Arg::with_name("time-unit")
+                .long("time-unit")
+                .short("u")
+                .takes_value(true)
+                .value_name("millisecond|second")
+                .possible_values(&["millisecond", "second"])
+                .help( "Set the time unit used for CLI output and Markdown export.",
+                ),
         )
         .arg(
             Arg::with_name("export-csv")

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -129,10 +129,9 @@ fn build_app() -> App<'static, 'static> {
                 .long("time-unit")
                 .short("u")
                 .takes_value(true)
-                .value_name("millisecond|second")
+                .value_name("UNIT")
                 .possible_values(&["millisecond", "second"])
-                .help( "Set the time unit used for CLI output and Markdown export.",
-                ),
+                .help("Set the time unit used. Possible values: millisecond, second."),
         )
         .arg(
             Arg::with_name("export-csv")

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -254,7 +254,7 @@ pub fn run_benchmark(
         run_preparation_command(&options.shell, &prepare_cmd, options.show_output)?;
 
         let msg = {
-            let mean = format_duration(mean(&times_real), None);
+            let mean = format_duration(mean(&times_real), options.time_unit);
             format!("Current estimate: {}", mean.to_string().green())
         };
         progress_bar.set_message(&msg);
@@ -287,7 +287,7 @@ pub fn run_benchmark(
     let system_mean = mean(&times_system);
 
     // Formatting and console output
-    let (mean_str, unit_mean) = format_duration_unit(t_mean, None);
+    let (mean_str, unit_mean) = format_duration_unit(t_mean, options.time_unit);
     let stddev_str = format_duration(t_stddev, Some(unit_mean));
     let min_str = format_duration(t_min, Some(unit_mean));
     let max_str = format_duration(t_max, Some(unit_mean));

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -11,8 +11,8 @@ use hyperfine::outlier_detection::{modified_zscores, OUTLIER_THRESHOLD};
 use hyperfine::shell::execute_and_time;
 use hyperfine::timer::wallclocktimer::WallClockTimer;
 use hyperfine::timer::{TimerStart, TimerStop};
-use hyperfine::types::{BenchmarkResult, Command};
-use hyperfine::types::{CmdFailureAction, HyperfineOptions, OutputStyleOption, Second};
+use hyperfine::types::{BenchmarkResult, Command, CmdFailureAction, HyperfineOptions, OutputStyleOption};
+use hyperfine::units::Second;
 use hyperfine::warnings::Warnings;
 
 /// Results from timing a single shell command

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -1,6 +1,6 @@
 use super::Exporter;
 
-use hyperfine::types::BenchmarkResult;
+use hyperfine::types::{BenchmarkResult, Unit};
 
 use std::io::{Error, ErrorKind, Result};
 
@@ -10,10 +10,10 @@ use csv::WriterBuilder;
 pub struct CsvExporter {}
 
 impl Exporter for CsvExporter {
-    fn serialize(&self, results: &Vec<BenchmarkResult>) -> Result<Vec<u8>> {
+    fn serialize(&self, results: &Vec<BenchmarkResult>, _unit: Option<Unit>) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
         for res in results {
-            // The list of times can not be exported to the CSV file - remove it:
+            // The list of times cannot be exported to the CSV file - remove it:
             let mut result = res.clone();
             result.times = None;
 

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -1,6 +1,7 @@
 use super::Exporter;
 
-use hyperfine::types::{BenchmarkResult, Unit};
+use hyperfine::types::BenchmarkResult;
+use hyperfine::units::Unit;
 
 use std::io::{Error, ErrorKind, Result};
 

--- a/src/hyperfine/export/json.rs
+++ b/src/hyperfine/export/json.rs
@@ -1,5 +1,6 @@
 use super::Exporter;
-use hyperfine::types::{BenchmarkResult, Unit};
+use hyperfine::types::BenchmarkResult;
+use hyperfine::units::Unit;
 
 use std::io::{Error, ErrorKind, Result};
 

--- a/src/hyperfine/export/json.rs
+++ b/src/hyperfine/export/json.rs
@@ -1,5 +1,5 @@
 use super::Exporter;
-use hyperfine::types::BenchmarkResult;
+use hyperfine::types::{BenchmarkResult, Unit};
 
 use std::io::{Error, ErrorKind, Result};
 
@@ -14,7 +14,7 @@ struct HyperfineSummary<'a> {
 pub struct JsonExporter {}
 
 impl Exporter for JsonExporter {
-    fn serialize(&self, results: &Vec<BenchmarkResult>) -> Result<Vec<u8>> {
+    fn serialize(&self, results: &Vec<BenchmarkResult>, _unit: Option<Unit>) -> Result<Vec<u8>> {
         let mut output = to_vec_pretty(&HyperfineSummary { results });
         for content in output.iter_mut() {
             content.push(b'\n');

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -1,7 +1,8 @@
 use super::Exporter;
 
 use hyperfine::format::format_duration_value;
-use hyperfine::types::{BenchmarkResult, Unit};
+use hyperfine::types::BenchmarkResult;
+use hyperfine::units::Unit;
 
 use std::io::Result;
 
@@ -10,9 +11,9 @@ pub struct MarkdownExporter {}
 
 impl Exporter for MarkdownExporter {
     fn serialize(&self, results: &Vec<BenchmarkResult>, unit: Option<Unit>) -> Result<Vec<u8>> {
-        let unit = if unit.is_some() {
+        let unit = if let Some(unit) = unit {
             // Use the given unit for all entries.
-            unit.unwrap()
+            unit
         } else if let Some(first_result) = results.first() {
             // Use the first BenchmarkResult entry to determine the unit for all entries.
             format_duration_value(first_result.mean, None).1

--- a/src/hyperfine/export/mod.rs
+++ b/src/hyperfine/export/mod.rs
@@ -9,7 +9,8 @@ use self::markdown::MarkdownExporter;
 use std::fs::File;
 use std::io::{Result, Write};
 
-use hyperfine::types::{BenchmarkResult, Unit};
+use hyperfine::types::BenchmarkResult;
+use hyperfine::units::Unit;
 
 /// The desired form of exporter to use for a given file.
 #[derive(Clone)]

--- a/src/hyperfine/export/mod.rs
+++ b/src/hyperfine/export/mod.rs
@@ -9,7 +9,7 @@ use self::markdown::MarkdownExporter;
 use std::fs::File;
 use std::io::{Result, Write};
 
-use hyperfine::types::BenchmarkResult;
+use hyperfine::types::{BenchmarkResult, Unit};
 
 /// The desired form of exporter to use for a given file.
 #[derive(Clone)]
@@ -27,7 +27,7 @@ pub enum ExportType {
 /// Interface for different exporters.
 trait Exporter {
     /// Export the given entries in the serialized form.
-    fn serialize(&self, results: &Vec<BenchmarkResult>) -> Result<Vec<u8>>;
+    fn serialize(&self, results: &Vec<BenchmarkResult>, unit: Option<Unit>) -> Result<Vec<u8>>;
 }
 
 struct ExporterWithFilename {
@@ -62,9 +62,9 @@ impl ExportManager {
     }
 
     /// Write the given results to all Exporters contained within this manager
-    pub fn write_results(&self, results: Vec<BenchmarkResult>) -> Result<()> {
+    pub fn write_results(&self, results: Vec<BenchmarkResult>, unit: Option<Unit>) -> Result<()> {
         for e in &self.exporters {
-            let file_content = e.exporter.serialize(&results)?;
+            let file_content = e.exporter.serialize(&results, unit)?;
             write_to_file(&e.filename, &file_content)?;
         }
         Ok(())

--- a/src/hyperfine/format.rs
+++ b/src/hyperfine/format.rs
@@ -1,28 +1,4 @@
-use hyperfine::types::Second;
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Unit {
-    Second,
-    MilliSecond,
-}
-
-impl Unit {
-    /// The abbreviation of the Unit.
-    pub fn short_name(&self) -> String {
-        match *self {
-            Unit::Second => String::from("s"),
-            Unit::MilliSecond => String::from("ms"),
-        }
-    }
-
-    /// Returns the Second value formatted for the Unit.
-    pub fn format(&self, value: Second) -> String {
-        match *self {
-            Unit::Second => format!("{:.3}", value),
-            Unit::MilliSecond => format!("{:.1}", value * 1e3),
-        }
-    }
-}
+use hyperfine::types::{Second, Unit};
 
 /// Format the given duration as a string. The output-unit can be enforced by setting `unit` to
 /// `Some(target_unit)`. If `unit` is `None`, it will be determined automatically.
@@ -46,20 +22,6 @@ pub fn format_duration_value(duration: Second, unit: Option<Unit>) -> (String, U
     } else {
         (Unit::Second.format(duration), Unit::Second)
     }
-}
-
-#[test]
-fn test_unit_short_name() {
-    assert_eq!("s", Unit::Second.short_name());
-    assert_eq!("ms", Unit::MilliSecond.short_name());
-}
-
-// Note - the values are rounded when formatted.
-#[test]
-fn test_unit_format() {
-    let value: Second = 123.456789;
-    assert_eq!("123.457", Unit::Second.format(value));
-    assert_eq!("123456.8", Unit::MilliSecond.format(value));
 }
 
 #[test]

--- a/src/hyperfine/format.rs
+++ b/src/hyperfine/format.rs
@@ -1,4 +1,4 @@
-use hyperfine::types::{Second, Unit};
+use hyperfine::units::{Second, Unit};
 
 /// Format the given duration as a string. The output-unit can be enforced by setting `unit` to
 /// `Some(target_unit)`. If `unit` is `None`, it will be determined automatically.

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -1,7 +1,8 @@
 use colored::*;
 use indicatif::{ProgressBar, ProgressStyle};
 
-use hyperfine::types::{BenchmarkResult, OutputStyleOption, Second};
+use hyperfine::types::{BenchmarkResult, OutputStyleOption};
+use hyperfine::units::Second;
 
 use std::cmp::Ordering;
 use std::iter::Iterator;

--- a/src/hyperfine/mod.rs
+++ b/src/hyperfine/mod.rs
@@ -8,4 +8,5 @@ pub mod outlier_detection;
 pub mod shell;
 pub mod timer;
 pub mod types;
+pub mod units;
 pub mod warnings;

--- a/src/hyperfine/timer/internal.rs
+++ b/src/hyperfine/timer/internal.rs
@@ -1,4 +1,4 @@
-use hyperfine::types::Second;
+use hyperfine::units::Second;
 
 #[derive(Debug, Copy, Clone)]
 pub struct CPUTimes {

--- a/src/hyperfine/timer/unix_timer.rs
+++ b/src/hyperfine/timer/unix_timer.rs
@@ -2,7 +2,7 @@
 
 use super::internal::{CPUInterval, CPUTimes};
 use hyperfine::timer::{TimerStart, TimerStop};
-use hyperfine::types::Second;
+use hyperfine::units::Second;
 
 use std::mem;
 use std::process::Child;

--- a/src/hyperfine/timer/wallclocktimer.rs
+++ b/src/hyperfine/timer/wallclocktimer.rs
@@ -2,7 +2,7 @@ use std::process::Child;
 use std::time::Instant;
 
 use hyperfine::timer::{TimerStart, TimerStop};
-use hyperfine::types::Second;
+use hyperfine::units::Second;
 
 pub struct WallClockTimer {
     start: Instant,

--- a/src/hyperfine/timer/windows_timer.rs
+++ b/src/hyperfine/timer/windows_timer.rs
@@ -1,8 +1,8 @@
 #![cfg(windows)]
 
 use super::internal::CPUTimes;
-use hyperfine::types::Second;
 use hyperfine::timer::{TimerStart, TimerStop};
+use hyperfine::units::Second;
 
 use winapi::um::processthreadsapi::GetProcessTimes;
 use winapi::um::winnt::HANDLE;

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -1,39 +1,13 @@
 /// This module contains common internal types.
 use std::fmt;
 
+use hyperfine::units::{Second, Unit};
+
 #[cfg(not(windows))]
 pub const DEFAULT_SHELL: &str = "sh";
 
 #[cfg(windows)]
 pub const DEFAULT_SHELL: &str = "cmd.exe";
-
-/// Type alias for unit of time
-pub type Second = f64;
-
-/// Supported time units
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Unit {
-    Second,
-    MilliSecond,
-}
-
-impl Unit {
-    /// The abbreviation of the Unit.
-    pub fn short_name(&self) -> String {
-        match *self {
-            Unit::Second => String::from("s"),
-            Unit::MilliSecond => String::from("ms"),
-        }
-    }
-
-    /// Returns the Second value formatted for the Unit.
-    pub fn format(&self, value: Second) -> String {
-        match *self {
-            Unit::Second => format!("{:.3}", value),
-            Unit::MilliSecond => format!("{:.1}", value * 1e3),
-        }
-    }
-}
 
 /// A command that should be benchmarked.
 #[derive(Debug, Clone)]
@@ -220,18 +194,4 @@ impl BenchmarkResult {
             times: Some(times),
         }
     }
-}
-
-#[test]
-fn test_unit_short_name() {
-    assert_eq!("s", Unit::Second.short_name());
-    assert_eq!("ms", Unit::MilliSecond.short_name());
-}
-
-// Note - the values are rounded when formatted.
-#[test]
-fn test_unit_format() {
-    let value: Second = 123.456789;
-    assert_eq!("123.457", Unit::Second.format(value));
-    assert_eq!("123456.8", Unit::MilliSecond.format(value));
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -10,6 +10,31 @@ pub const DEFAULT_SHELL: &str = "cmd.exe";
 /// Type alias for unit of time
 pub type Second = f64;
 
+/// Supported time units
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Unit {
+    Second,
+    MilliSecond,
+}
+
+impl Unit {
+    /// The abbreviation of the Unit.
+    pub fn short_name(&self) -> String {
+        match *self {
+            Unit::Second => String::from("s"),
+            Unit::MilliSecond => String::from("ms"),
+        }
+    }
+
+    /// Returns the Second value formatted for the Unit.
+    pub fn format(&self, value: Second) -> String {
+        match *self {
+            Unit::Second => format!("{:.3}", value),
+            Unit::MilliSecond => format!("{:.1}", value * 1e3),
+        }
+    }
+}
+
 /// A command that should be benchmarked.
 #[derive(Debug, Clone)]
 pub struct Command<'a> {
@@ -122,6 +147,9 @@ pub struct HyperfineOptions {
 
     /// Forward benchmark's stdout to hyperfine's stdout
     pub show_output: bool,
+
+    /// Which time unit to use for CLI & Markdown output
+    pub time_unit: Option<Unit>,
 }
 
 impl Default for HyperfineOptions {
@@ -135,6 +163,7 @@ impl Default for HyperfineOptions {
             output_style: OutputStyleOption::Full,
             shell: DEFAULT_SHELL.to_string(),
             show_output: false,
+            time_unit: None,
         }
     }
 }
@@ -191,4 +220,18 @@ impl BenchmarkResult {
             times: Some(times),
         }
     }
+}
+
+#[test]
+fn test_unit_short_name() {
+    assert_eq!("s", Unit::Second.short_name());
+    assert_eq!("ms", Unit::MilliSecond.short_name());
+}
+
+// Note - the values are rounded when formatted.
+#[test]
+fn test_unit_format() {
+    let value: Second = 123.456789;
+    assert_eq!("123.457", Unit::Second.format(value));
+    assert_eq!("123456.8", Unit::MilliSecond.format(value));
 }

--- a/src/hyperfine/units.rs
+++ b/src/hyperfine/units.rs
@@ -1,0 +1,43 @@
+/// This module contains common units.
+
+/// Type alias for unit of time
+pub type Second = f64;
+
+/// Supported time units
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Unit {
+    Second,
+    MilliSecond,
+}
+
+impl Unit {
+    /// The abbreviation of the Unit.
+    pub fn short_name(&self) -> String {
+        match *self {
+            Unit::Second => String::from("s"),
+            Unit::MilliSecond => String::from("ms"),
+        }
+    }
+
+    /// Returns the Second value formatted for the Unit.
+    pub fn format(&self, value: Second) -> String {
+        match *self {
+            Unit::Second => format!("{:.3}", value),
+            Unit::MilliSecond => format!("{:.1}", value * 1e3),
+        }
+    }
+}
+
+#[test]
+fn test_unit_short_name() {
+    assert_eq!("s", Unit::Second.short_name());
+    assert_eq!("ms", Unit::MilliSecond.short_name());
+}
+
+// Note - the values are rounded when formatted.
+#[test]
+fn test_unit_format() {
+    let value: Second = 123.456789;
+    assert_eq!("123.457", Unit::Second.format(value));
+    assert_eq!("123456.8", Unit::MilliSecond.format(value));
+}

--- a/src/hyperfine/warnings.rs
+++ b/src/hyperfine/warnings.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use hyperfine::format::format_duration;
 use hyperfine::internal::MIN_EXECUTION_TIME;
-use hyperfine::types::Second;
+use hyperfine::units::Second;
 
 /// A list of all possible warnings
 pub enum Warnings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,9 @@ use hyperfine::error::{OptionsError, ParameterScanError};
 use hyperfine::export::{ExportManager, ExportType};
 use hyperfine::internal::write_benchmark_comparison;
 use hyperfine::types::{
-    BenchmarkResult, Unit, CmdFailureAction, Command, HyperfineOptions, OutputStyleOption,
+    BenchmarkResult, CmdFailureAction, Command, HyperfineOptions, OutputStyleOption,
 };
+use hyperfine::units::Unit;
 
 /// Print error message to stderr and terminate
 pub fn error(message: &str) -> ! {
@@ -95,9 +96,9 @@ fn main() {
     let export_manager = build_export_manager(&matches);
     let commands = build_commands(&matches);
 
-    let res = match &options {
-        &Ok(ref opts) => run(&commands, &opts),
-        &Err(ref e) => error(e.description()),
+    let res = match options {
+        Ok(ref opts) => run(&commands, &opts),
+        Err(ref e) => error(e.description()),
     };
 
     match res {


### PR DESCRIPTION
Add option to set the time units to either `MilliSecond` or `Second`
for both CLI output and Markdown export, overriding the default logic.