### PR TITLE
Add option to set the shell, closes #61

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -110,6 +110,15 @@ fn build_app() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("shell")
+                .long("shell")
+                .short("S")
+                .takes_value(true)
+                .value_name("SHELL")
+                .overrides_with("shell")
+                .help("Set the shell to use (default: sh) for executing benchmarked commands."),
+        )
+        .arg(
             Arg::with_name("ignore-failure")
                 .long("ignore-failure")
                 .short("i")

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -1,6 +1,12 @@
 /// This module contains common internal types.
 use std::fmt;
 
+#[cfg(not(windows))]
+pub const DEFAULT_SHELL: &str = "sh";
+
+#[cfg(windows)]
+pub const DEFAULT_SHELL: &str = "cmd.exe";
+
 /// Type alias for unit of time
 pub type Second = f64;
 
@@ -111,6 +117,9 @@ pub struct HyperfineOptions {
     /// What color mode to use for output
     pub output_style: OutputStyleOption,
 
+    /// The shell to use for executing commands.
+    pub shell: String,
+
     /// Forward benchmark's stdout to hyperfine's stdout
     pub show_output: bool,
 }
@@ -124,6 +133,7 @@ impl Default for HyperfineOptions {
             failure_action: CmdFailureAction::RaiseError,
             preparation_command: None,
             output_style: OutputStyleOption::Full,
+            shell: DEFAULT_SHELL.to_string(),
             show_output: false,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ pub fn error(message: &str) -> ! {
 
 /// Runs the benchmark for the given commands
 fn run(commands: &Vec<Command>, options: &HyperfineOptions) -> io::Result<Vec<BenchmarkResult>> {
-    let shell_spawning_time = mean_shell_spawning_time(&options.output_style, options.show_output)?;
+    let shell_spawning_time = mean_shell_spawning_time(&options.shell, &options.output_style, options.show_output)?;
 
     let mut timing_results = vec![];
 
@@ -123,7 +123,7 @@ fn build_hyperfine_options(matches: &ArgMatches) -> Result<HyperfineOptions, Opt
     options.warmup_count = matches
         .value_of("warmup")
         .and_then(&str_to_u64)
-        .unwrap_or(0);
+        .unwrap_or(options.warmup_count);
 
     let mut min_runs = matches.value_of("min-runs").and_then(&str_to_u64);
     let mut max_runs = matches.value_of("max-runs").and_then(&str_to_u64);
@@ -188,7 +188,9 @@ fn build_hyperfine_options(matches: &ArgMatches) -> Result<HyperfineOptions, Opt
             colored::control::set_override(false)
         }
         _ => {}
-    }
+    };
+
+    options.shell = matches.value_of("shell").unwrap_or(&options.shell).to_string();
 
     if matches.is_present("ignore-failure") {
         options.failure_action = CmdFailureAction::Ignore;


### PR DESCRIPTION
Allow the user to set the shell used for executing benchmark commands.

The option (-S/--shell) can be overridden, when there are duplicate
options the last option's value will be used.