### PR TITLE
Add support for building a snap via snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: hyperfine
+version: git
+summary: "A command-line benchmarking tool"
+description: |
+  A command-line benchmarking tool (inspired by bench). 
+  Features
+    * Statistical analysis across multiple runs.
+    * Support for arbitrary shell commands.
+    * Constant feedback about the benchmark progress and current estimates.
+    * Warmup runs can be executed before the actual benchmark.
+    * Cache-clearing commands can be set up before each timing run.
+    * Statistical outlier detection.
+    * Export results to various formats: CSV, JSON, Markdown.
+    * Parameterized benchmarks.
+    * Cross-platform
+
+grade: stable
+confinement: classic
+
+parts:
+  hyperfine:
+    plugin: rust
+    source: ./
+
+apps:
+  hyperfine:
+    command: bin/hyperfine


### PR DESCRIPTION
I created a snap package of hyperfine so it can be featured to the millions of Linux users installing apps from the [Snap Store](https://snapcraft.io/store). If you're willing to publish this under the hyperfine project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the hyperfine name](https://snapcraft.io/register-snap).

The snap file created by snapcraft can then be released in the Snap Store with snap push --release stable *.snap. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

Once in the snap store, you’ll need to [request classic confinement](https://forum.snapcraft.io/t/process-for-reviewing-classic-confinement-snaps/1460) with a [forum post](https://forum.snapcraft.io/), because hyperfine will need to be unconfined (via classic confinement) so it has access to the entire filesystem.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of hyperfine, and push them to the store automatically.

Thanks for making hyperfine! :)
