### PR TITLE
Serialize command parameters to data output files

### DIFF
--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -412,5 +412,6 @@ pub fn run_benchmark(
         t_min,
         t_max,
         times_real,
+        cmd.get_parameter().map(|p| p.1),
     ))
 }

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -83,6 +83,7 @@ fn test_markdown_format_ms() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
+        None,                // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -94,6 +95,7 @@ fn test_markdown_format_ms() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
+        None,                // parameter
     ));
 
     let formatted = String::from_utf8(exporter.serialize(&timing_results, None).unwrap()).unwrap();
@@ -126,6 +128,7 @@ fn test_markdown_format_s() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
+        None,                // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -137,6 +140,7 @@ fn test_markdown_format_s() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
+        None,                // parameter
     ));
 
     let formatted = String::from_utf8(exporter.serialize(&timing_results, None).unwrap()).unwrap();
@@ -168,6 +172,7 @@ fn test_markdown_format_time_unit_s() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
+        None,                // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -179,6 +184,7 @@ fn test_markdown_format_time_unit_s() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
+        None,                // parameter
     ));
 
     let formatted = String::from_utf8(
@@ -216,6 +222,7 @@ fn test_markdown_format_time_unit_ms() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
+        None,                // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -227,6 +234,7 @@ fn test_markdown_format_time_unit_ms() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
+        None,                // parameter
     ));
 
     let formatted = String::from_utf8(

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -173,6 +173,10 @@ pub struct BenchmarkResult {
     /// All run time measurements
     #[serde(skip_serializing_if = "Option::is_none")]
     pub times: Option<Vec<Second>>,
+
+    /// Any parameter used
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameter: Option<i32>,
 }
 
 impl BenchmarkResult {
@@ -186,6 +190,7 @@ impl BenchmarkResult {
         min: Second,
         max: Second,
         times: Vec<Second>,
+        parameter: Option<i32>,
     ) -> Self {
         BenchmarkResult {
             command,
@@ -196,6 +201,7 @@ impl BenchmarkResult {
             min,
             max,
             times: Some(times),
+            parameter,
         }
     }
 }


### PR DESCRIPTION
This patch adds any parameter used to data output files (currently JSON
and CSV files). With that users have direct access to both input values
(i.e., benchmark parameters) and the resulting timings which should
simplify follow-up analyses.