### PR TITLE
Export relative speed

### DIFF
--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -1,6 +1,7 @@
 use super::Exporter;
 
 use crate::hyperfine::format::format_duration_value;
+use crate::hyperfine::internal::{compute_relative_speed, BenchmarkResultWithRelativeSpeed};
 use crate::hyperfine::types::BenchmarkResult;
 use crate::hyperfine::units::Unit;
 
@@ -22,10 +23,12 @@ impl Exporter for MarkdownExporter {
             Unit::Second
         };
 
+        let annotated_results = compute_relative_speed(&results);
+
         let mut destination = start_table(unit);
 
-        for result in results {
-            add_table_row(&mut destination, result, unit);
+        for result in annotated_results {
+            add_table_row(&mut destination, &result, unit);
         }
 
         Ok(destination)
@@ -34,7 +37,7 @@ impl Exporter for MarkdownExporter {
 
 fn table_header(unit_short_name: String) -> String {
     format!(
-        "| Command | Mean [{unit}] | Min…Max [{unit}] |\n|:---|---:|---:|\n",
+        "| Command | Mean [{unit}] | Min…Max [{unit}] | Relative |\n|:---|---:|---:|---:|\n",
         unit = unit_short_name
     )
 }
@@ -43,20 +46,23 @@ fn start_table(unit: Unit) -> Vec<u8> {
     table_header(unit.short_name()).bytes().collect()
 }
 
-fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResult, unit: Unit) {
-    let mean_str = format_duration_value(entry.mean, Some(unit)).0;
-    let stddev_str = format_duration_value(entry.stddev, Some(unit)).0;
-    let min_str = format_duration_value(entry.min, Some(unit)).0;
-    let max_str = format_duration_value(entry.max, Some(unit)).0;
+fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResultWithRelativeSpeed, unit: Unit) {
+    let result = &entry.result;
+    let mean_str = format_duration_value(result.mean, Some(unit)).0;
+    let stddev_str = format_duration_value(result.stddev, Some(unit)).0;
+    let min_str = format_duration_value(result.min, Some(unit)).0;
+    let max_str = format_duration_value(result.max, Some(unit)).0;
+    let rel_str = format!("{:.1}", entry.relative_speed);
 
     dest.extend(
         format!(
-            "| `{command}` | {mean} ± {stddev} | {min}…{max} |\n",
-            command = entry.command.replace("|", "\\|"),
+            "| `{command}` | {mean} ± {stddev} | {min}…{max} | {rel} |\n",
+            command = result.command.replace("|", "\\|"),
             mean = mean_str,
             stddev = stddev_str,
             min = min_str,
             max = max_str,
+            rel = rel_str,
         )
         .as_bytes(),
     );
@@ -102,8 +108,8 @@ fn test_markdown_format_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 |
-| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 | 1.0 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 | 19.0 |
 ",
         table_header("ms".to_string())
     );
@@ -147,8 +153,8 @@ fn test_markdown_format_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 |
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 |
+| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 | 19.0 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 | 1.0 |
 ",
         table_header("s".to_string())
     );
@@ -196,8 +202,8 @@ fn test_markdown_format_time_unit_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 |
-| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 | 1.0 |
+| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 | 19.0 |
 ",
         table_header("s".to_string())
     );
@@ -246,8 +252,8 @@ fn test_markdown_format_time_unit_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 |
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 | 19.0 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 | 1.0 |
 ",
         table_header("ms".to_string())
     );

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -37,7 +37,7 @@ impl Exporter for MarkdownExporter {
 
 fn table_header(unit_short_name: String) -> String {
     format!(
-        "| Command | Mean [{unit}] | Min…Max [{unit}] | Relative |\n|:---|---:|---:|---:|\n",
+        "| Command | Mean [{unit}] | Min [{unit}] | Max [{unit}] | Relative |\n|:---|---:|---:|---:|---:|\n",
         unit = unit_short_name
     )
 }
@@ -56,7 +56,7 @@ fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResultWithRelativeSpeed, u
 
     dest.extend(
         format!(
-            "| `{command}` | {mean} ± {stddev} | {min}…{max} | {rel} |\n",
+            "| `{command}` | {mean} ± {stddev} | {min} | {max} | {rel} |\n",
             command = result.command.replace("|", "\\|"),
             mean = mean_str,
             stddev = stddev_str,
@@ -108,8 +108,8 @@ fn test_markdown_format_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 | 1.0 |
-| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 | 19.0 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.0 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 19.0 |
 ",
         table_header("ms".to_string())
     );
@@ -153,8 +153,8 @@ fn test_markdown_format_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 | 19.0 |
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 | 1.0 |
+| `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 19.0 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.0 |
 ",
         table_header("s".to_string())
     );
@@ -202,8 +202,8 @@ fn test_markdown_format_time_unit_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102…0.108 | 1.0 |
-| `sleep 2` | 2.005 ± 0.002 | 2.002…2.008 | 19.0 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.0 |
+| `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 19.0 |
 ",
         table_header("s".to_string())
     );
@@ -252,8 +252,8 @@ fn test_markdown_format_time_unit_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 2` | 2005.0 ± 2.0 | 2002.0…2008.0 | 19.0 |
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3…108.0 | 1.0 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 19.0 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.0 |
 ",
         table_header("ms".to_string())
     );

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -47,9 +47,9 @@ pub fn min(vals: &[f64]) -> f64 {
 }
 
 pub struct BenchmarkResultWithRelativeSpeed<'a> {
-    result: &'a BenchmarkResult,
-    relative_speed: Scalar,
-    relative_speed_stddev: Scalar,
+    pub result: &'a BenchmarkResult,
+    pub relative_speed: Scalar,
+    pub relative_speed_stddev: Scalar,
 }
 
 fn compare_mean_time(l: &BenchmarkResult, r: &BenchmarkResult) -> Ordering {
@@ -72,9 +72,8 @@ pub fn compute_relative_speed<'a>(
             // https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
             // Covariance asssumed to be 0, i.e. variables are assumed to be independent
             let ratio_stddev = ratio
-                * ((result.stddev / result.mean).powi(2)
-                    + (fastest.stddev / fastest.mean).powi(2))
-                .sqrt();
+                * ((result.stddev / result.mean).powi(2) + (fastest.stddev / fastest.mean).powi(2))
+                    .sqrt();
 
             BenchmarkResultWithRelativeSpeed {
                 result,
@@ -122,18 +121,16 @@ fn test_max() {
 fn test_compute_relative_speed() {
     use approx::assert_relative_eq;
 
-    let create_result = |name: &str, mean| {
-        BenchmarkResult {
-            command: name.into(),
-            mean: mean,
-            stddev: 1.0,
-            user: mean,
-            system: 0.0,
-            min: mean,
-            max: mean,
-            times: None,
-            parameter: None,
-        }
+    let create_result = |name: &str, mean| BenchmarkResult {
+        command: name.into(),
+        mean: mean,
+        stddev: 1.0,
+        user: mean,
+        system: 0.0,
+        min: mean,
+        max: mean,
+        times: None,
+        parameter: None,
     };
 
     let results = vec![

--- a/src/hyperfine/units.rs
+++ b/src/hyperfine/units.rs
@@ -1,7 +1,9 @@
 /// This module contains common units.
 
+pub type Scalar = f64;
+
 /// Type alias for unit of time
-pub type Second = f64;
+pub type Second = Scalar;
 
 /// Supported time units
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,10 @@ pub fn error(message: &str) -> ! {
 }
 
 /// Runs the benchmark for the given commands
-fn run(commands: &Vec<Command<'_>>, options: &HyperfineOptions) -> io::Result<Vec<BenchmarkResult>> {
+fn run(
+    commands: &Vec<Command<'_>>,
+    options: &HyperfineOptions,
+) -> io::Result<Vec<BenchmarkResult>> {
     let shell_spawning_time =
         mean_shell_spawning_time(&options.shell, &options.output_style, options.show_output)?;
 


### PR DESCRIPTION
* Add "Relative" speed column to the markdown export
* Split Min and Max into two separate columns

This is how the new output looks like:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `sleep 0.1` | 105.0 ± 1.7 | 101.2 | 108.0 | 1.0 |
| `sleep 0.15` | 155.3 ± 2.6 | 150.7 | 159.2 | 1.5 |
| `sleep 0.2` | 206.6 ± 1.8 | 202.9 | 209.2 | 2.0 |

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `find . -iregex '.*[0-9]\.jpg$'` | 125.3 ± 1.9 | 120.9 | 127.5 | 5.8 |
| `find . -iname '*[0-9].jpg'` | 103.5 ± 1.1 | 101.7 | 106.2 | 4.8 |
| `fd -HI '.*[0-9]\.jpg$'` | 21.5 ± 2.2 | 20.1 | 35.5 | 1.0 |


closes #127 