### PR TITLE
Add median run time to CSV and JSON export formats

### DIFF
--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::process::Stdio;
 
 use colored::*;
-use statistical::{mean, standard_deviation};
+use statistical::{mean, median, standard_deviation};
 
 use crate::hyperfine::format::{format_duration, format_duration_unit};
 use crate::hyperfine::internal::{get_progress_bar, max, min, MIN_EXECUTION_TIME};
@@ -313,6 +313,7 @@ pub fn run_benchmark(
     let t_num = times_real.len();
     let t_mean = mean(&times_real);
     let t_stddev = standard_deviation(&times_real, Some(t_mean));
+    let t_median = median(&times_real);
     let t_min = min(&times_real);
     let t_max = max(&times_real);
 
@@ -394,6 +395,7 @@ pub fn run_benchmark(
         cmd.get_shell_command(),
         t_mean,
         t_stddev,
+        t_median,
         user_mean,
         system_mean,
         t_min,

--- a/src/hyperfine/export/asciidoc.rs
+++ b/src/hyperfine/export/asciidoc.rs
@@ -87,6 +87,7 @@ fn test_asciidoc_table_row() {
         String::from("sleep 1"), // command
         0.10491992406666667,     // mean
         0.00397851689425097,     // stddev
+        0.10491992406666667,     // median
         0.005182013333333333,    // user
         0.0,                     // system
         0.1003342584,            // min
@@ -137,6 +138,7 @@ fn test_asciidoc_table_row_command_escape() {
         String::from("sleep 1|"), // command
         0.10491992406666667,      // mean
         0.00397851689425097,      // stddev
+        0.10491992406666667,      // median
         0.005182013333333333,     // user
         0.0,                      // system
         0.1003342584,             // min
@@ -174,6 +176,7 @@ fn test_asciidoc() {
             String::from("command | 1"),
             1.0,
             2.0,
+            1.0,
             3.0,
             4.0,
             5.0,
@@ -185,6 +188,7 @@ fn test_asciidoc() {
             String::from("command | 2"),
             11.0,
             12.0,
+            11.0,
             13.0,
             14.0,
             15.0,

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -84,6 +84,7 @@ fn test_markdown_format_ms() {
         String::from("sleep 0.1"),
         0.1057,              // mean
         0.0016,              // std dev
+        0.1057,              // median
         0.0009,              // user_mean
         0.0011,              // system_mean
         0.1023,              // min
@@ -96,6 +97,7 @@ fn test_markdown_format_ms() {
         String::from("sleep 2"),
         2.0050,              // mean
         0.0020,              // std dev
+        2.0050,              // median
         0.0009,              // user_mean
         0.0012,              // system_mean
         2.0020,              // min
@@ -129,6 +131,7 @@ fn test_markdown_format_s() {
         String::from("sleep 2"),
         2.0050,              // mean
         0.0020,              // std dev
+        2.0050,              // median
         0.0009,              // user_mean
         0.0012,              // system_mean
         2.0020,              // min
@@ -141,6 +144,7 @@ fn test_markdown_format_s() {
         String::from("sleep 0.1"),
         0.1057,              // mean
         0.0016,              // std dev
+        0.1057,              // median
         0.0009,              // user_mean
         0.0011,              // system_mean
         0.1023,              // min
@@ -173,6 +177,7 @@ fn test_markdown_format_time_unit_s() {
         String::from("sleep 0.1"),
         0.1057,              // mean
         0.0016,              // std dev
+        0.1057,              // median
         0.0009,              // user_mean
         0.0011,              // system_mean
         0.1023,              // min
@@ -185,6 +190,7 @@ fn test_markdown_format_time_unit_s() {
         String::from("sleep 2"),
         2.0050,              // mean
         0.0020,              // std dev
+        2.0050,              // median
         0.0009,              // user_mean
         0.0012,              // system_mean
         2.0020,              // min
@@ -223,6 +229,7 @@ fn test_markdown_format_time_unit_ms() {
         String::from("sleep 2"),
         2.0050,              // mean
         0.0020,              // std dev
+        2.0050,              // median
         0.0009,              // user_mean
         0.0012,              // system_mean
         2.0020,              // min
@@ -235,6 +242,7 @@ fn test_markdown_format_time_unit_ms() {
         String::from("sleep 0.1"),
         0.1057,              // mean
         0.0016,              // std dev
+        0.1057,              // median
         0.0009,              // user_mean
         0.0011,              // system_mean
         0.1023,              // min

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -125,6 +125,7 @@ fn test_compute_relative_speed() {
         command: name.into(),
         mean: mean,
         stddev: 1.0,
+        median: mean,
         user: mean,
         system: 0.0,
         min: mean,

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -159,6 +159,9 @@ pub struct BenchmarkResult {
     /// The standard deviation of all run times
     pub stddev: Second,
 
+    /// The median run time
+    pub median: Second,
+
     /// Time spend in user space
     pub user: Second,
 
@@ -186,6 +189,7 @@ impl BenchmarkResult {
         command: String,
         mean: Second,
         stddev: Second,
+        median: Second,
         user: Second,
         system: Second,
         min: Second,
@@ -197,6 +201,7 @@ impl BenchmarkResult {
             command,
             mean,
             stddev,
+            median,
             user,
             system,
             min,


### PR DESCRIPTION
closes #171 
```json
{
  "results": [
    {
      "command": "sleep 0.1",
      "mean": 0.10479531597500001,
      "stddev": 0.0028952282760556763,
      "median": 0.103899629975,
      "user": 0.0018704149999999996,
      "system": 0.0027805025,
      "min": 0.102477719475,
      "max": 0.108904284475,
      "times": [
        0.102477719475,
        0.103097240475,
        0.108904284475,
        0.104702019475
      ]
    },
    {
      "command": "sleep 0.15",
      "mean": 0.155849670225,
      "stddev": 0.0015191348863954144,
      "median": 0.156060130475,
      "user": 0.0038596649999999995,
      "system": 0.0018617525000000001,
      "min": 0.153803724475,
      "max": 0.157474695475,
      "times": [
        0.157474695475,
        0.153803724475,
        0.15612386547499998,
        0.155996395475
      ]
    }
  ]
}
```
```csv
command,mean,stddev,median,user,system,min,max
sleep 0.1,0.10479531597500001,0.0028952282760556763,0.103899629975,0.0018704149999999996,0.0027805025,0.102477719475,0.108904284475
sleep 0.15,0.155849670225,0.0015191348863954144,0.156060130475,0.0038596649999999995,0.0018617525000000001,0.153803724475,0.157474695475
```