### PR TITLE
Enable link-time optimization for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ features = ["suggestions", "color", "wrap_help"]
 
 [dev-dependencies]
 approx = "0.3"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This makes binaries slightly smaller (about 230 KB less for a 64-bit Linux binary), at the cost of longer build times.