### PR TITLE
Add multiple --prepare support

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -76,10 +76,14 @@ fn build_app() -> App<'static, 'static> {
                 .long("prepare")
                 .short("p")
                 .takes_value(true)
+                .multiple(true)
+                .number_of_values(1)
                 .value_name("CMD")
                 .help(
-                    "Execute CMD before each timing run. This is useful for \
-                     clearing disk caches, for example.",
+                    "Execute CMD before each timing run. For example, this is \
+                     useful for clearing disk caches. This can be mentioned \
+                     out multiple time for each command or only one time for \
+                     all command.",
                 ),
         )
         .arg(

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -80,10 +80,11 @@ fn build_app() -> App<'static, 'static> {
                 .number_of_values(1)
                 .value_name("CMD")
                 .help(
-                    "Execute CMD before each timing run. For example, this is \
-                     useful for clearing disk caches. This can be mentioned \
-                     out multiple time for each command or only one time for \
-                     all command.",
+                    "Execute CMD before each timing run. This is useful for \
+                     clearing disk caches, for example. \nThe --prepare option can \
+                     be specified once for all commands or multiple times, once for \
+                     each command. In the latter case, each preparation command will \
+                     be run prior to the corresponding benchmark command.",
                 ),
         )
         .arg(

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -81,7 +81,7 @@ fn build_app() -> App<'static, 'static> {
                 .value_name("CMD")
                 .help(
                     "Execute CMD before each timing run. This is useful for \
-                     clearing disk caches, for example. \nThe --prepare option can \
+                     clearing disk caches, for example.\nThe --prepare option can \
                      be specified once for all commands or multiple times, once for \
                      each command. In the latter case, each preparation command will \
                      be run prior to the corresponding benchmark command.",

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -236,11 +236,8 @@ pub fn run_benchmark(
     // Run init command
     let mut prepare_cmd = None;
     if let Some(values) = &options.preparation_command {
-        if num >= values.len() {
-            prepare_cmd = Some(new_command_from_get_parameter(
-                cmd,
-                &values[values.len() - 1],
-            ));
+        if values.len() == 1 {
+            prepare_cmd = Some(new_command_from_get_parameter(cmd, &values[0]));
         } else {
             prepare_cmd = Some(new_command_from_get_parameter(cmd, &values[num]));
         }

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -235,15 +235,14 @@ pub fn run_benchmark(
 
     // Run init command
     let prepare_cmd = options.preparation_command.as_ref().map(|values| {
-        let corresponding_prepare_cmd = match values.len() {
-            1 => &values[0],
-            _ => &values[num],
+        let preparation_command = if values.len() == 1 {
+            &values[0]
+        } else {
+            &values[num]
         };
         match cmd.get_parameter() {
-            Some((param, value)) => {
-                Command::new_parametrized(corresponding_prepare_cmd, param, value)
-            }
-            None => Command::new(corresponding_prepare_cmd),
+            Some((param, value)) => Command::new_parametrized(preparation_command, param, value),
+            None => Command::new(preparation_command),
         }
     });
 

--- a/src/hyperfine/timer/windows_timer.rs
+++ b/src/hyperfine/timer/windows_timer.rs
@@ -65,7 +65,8 @@ fn get_cpu_times(handle: RawHandle) -> CPUTimes {
             // Extract times as laid out here: https://support.microsoft.com/en-us/help/188768/info-working-with-the-filetime-structure
             // Both user_time and kernel_time are spans that the proces spent in either.
             let user: i64 = (((user_time.dwHighDateTime as i64) << 32)
-                + user_time.dwLowDateTime as i64) / HUNDRED_NS_PER_MS;
+                + user_time.dwLowDateTime as i64)
+                / HUNDRED_NS_PER_MS;
             let kernel: i64 = (((kernel_time.dwHighDateTime as i64) << 32)
                 + kernel_time.dwLowDateTime as i64)
                 / HUNDRED_NS_PER_MS;

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -145,7 +145,7 @@ pub struct HyperfineOptions {
     pub failure_action: CmdFailureAction,
 
     /// Command to run before each timing run
-    pub preparation_command: Option<String>,
+    pub preparation_command: Option<Vec<String>>,
 
     /// Command to run after each benchmark
     pub cleanup_command: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,11 +123,9 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
         (None, None) => {}
     };
 
-    if let Some(values) = matches.values_of("prepare") {
-        options.preparation_command = Some(values.map(String::from).collect::<Vec<String>>());
-    } else {
-        options.preparation_command = None;
-    }
+    options.preparation_command = matches
+        .values_of("prepare")
+        .map(|values| values.map(String::from).collect::<Vec<String>>());
 
     options.cleanup_command = matches.value_of("cleanup").map(String::from);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,11 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
         (None, None) => {}
     };
 
-    options.preparation_command = matches.value_of("prepare").map(String::from);
+    if let Some(values) = matches.values_of("prepare") {
+        options.preparation_command = Some(values.map(String::from).collect::<Vec<String>>());
+    } else {
+        options.preparation_command = None;
+    }
 
     options.cleanup_command = matches.value_of("cleanup").map(String::from);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,16 @@ fn run(commands: &[Command<'_>], options: &HyperfineOptions) -> io::Result<Vec<B
 
     let mut timing_results = vec![];
 
+    // Check if preparation command is equal to command length or should be mentioned only once
+    if let Some(preparation_command) = &options.preparation_command {
+        if commands.len() != preparation_command.len() && preparation_command.len() > 1 {
+            error(
+                "--prepare option should be provided only 1 time or N times equal to number of \
+                 commands to benchmark",
+            );
+        }
+    }
+
     // Run the benchmarks
     for (num, cmd) in commands.iter().enumerate() {
         timing_results.push(run_benchmark(num, cmd, shell_spawning_time, options)?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,12 +33,11 @@ fn run(commands: &[Command<'_>], options: &HyperfineOptions) -> io::Result<Vec<B
 
     let mut timing_results = vec![];
 
-    // Check if preparation command is equal to command length or should be mentioned only once
     if let Some(preparation_command) = &options.preparation_command {
-        if commands.len() != preparation_command.len() && preparation_command.len() > 1 {
+        if preparation_command.len() > 1 && commands.len() != preparation_command.len() {
             error(
-                "--prepare option should be provided only 1 time or N times equal to number of \
-                 commands to benchmark",
+                "The '--prepare' option has to be provided just once or N times, where N is the \
+                 number of benchmark commands.",
             );
         }
     }


### PR DESCRIPTION
Add support for multiple --prepare option. Corresponding --prepare option will be used for command for benchmarking according to position. If --prepare option is less than benchmark command then all other remaining benchmark command will use last prepare option ( This logic may not be best logic to implement out). If prepare option is more than command for benchmarking then extra --prepare option will not be used
Part of #216