### PR TITLE
Add support to run preparation command only once while benchmarking

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -83,6 +83,16 @@ fn build_app() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("prepare-once")
+                .long("prepare-once")
+                .short("o")
+                .requires("prepare")
+                .help(
+                    "Execute prepare command only once initially for benchmarking. \
+                    Required to have --prepare option specified as well"
+                ),
+        )
+        .arg(
             Arg::with_name("cleanup")
                 .long("cleanup")
                 .short("c")

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -147,6 +147,9 @@ pub struct HyperfineOptions {
     /// Command to run before each timing run
     pub preparation_command: Option<String>,
 
+    /// Run preparation command only one time
+    pub preparation_once: bool,
+
     /// Command to run after each benchmark
     pub cleanup_command: Option<String>,
 
@@ -171,6 +174,7 @@ impl Default for HyperfineOptions {
             min_time_sec: 3.0,
             failure_action: CmdFailureAction::RaiseError,
             preparation_command: None,
+            preparation_once: false,
             cleanup_command: None,
             output_style: OutputStyleOption::Full,
             shell: DEFAULT_SHELL.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,8 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
 
     options.preparation_command = matches.value_of("prepare").map(String::from);
 
+    options.preparation_once = matches.is_present("prepare-once");
+
     options.cleanup_command = matches.value_of("cleanup").map(String::from);
 
     options.show_output = matches.is_present("show-output");


### PR DESCRIPTION
Add support to run preparation command only once. This PR adds out new option `-o/--prepare-once` option which causes to run preparation command only one time instead of running multiple time every time before running benchmark command which is current unchangeable options.

Part of #216