### PR TITLE
doc: addd pre-requisites to scripts documentation

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,16 @@
 This folder contains scripts that can be used in combination with hyperfines `--export-json` option.
 
+### Pre-requisites
+
+To make theses scripts work, you will need matplotlib installed. Just execute the following commands:
+
+```bash
+pip install matplotlib
+
+# If you're using python 3
+pip3 install matplotlib
+```
+
 ### Example:
 
 ``` bash


### PR DESCRIPTION
I encountered the "matplotlib missing" problem myself when using your tool. I wanted to add this documentation for people not familiar with pip or python.

Thanks for developing this tool, it's great !