### PR TITLE
Option to disable the default output entirely [#193]

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -125,13 +125,14 @@ fn build_app() -> App<'static, 'static> {
                 .short("s")
                 .takes_value(true)
                 .value_name("TYPE")
-                .possible_values(&["auto", "basic", "full", "nocolor", "color"])
+                .possible_values(&["auto", "basic", "full", "nocolor", "color", "none"])
                 .help(
                     "Set output style type (default: auto). Set this to 'basic' to disable output \
                      coloring and interactive elements. Set it to 'full' to enable all effects \
                      even if no interactive terminal was detected. Set this to 'nocolor' to \
                      keep the interactive output without any colors. Set this to 'color' to keep \
-                     the colors without any interactive output.",
+                     the colors without any interactive output. Set this to 'none' to disable all \
+                     the output of the tool.",
                 ),
         )
         .arg(

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -387,7 +387,7 @@ pub fn run_benchmark(
         warnings.push(Warnings::OutliersDetected);
     }
 
-    if !warnings.is_empty() {
+    if !warnings.is_empty() && options.output_style != OutputStyleOption::None {
         eprintln!(" ");
 
         for warning in &warnings {

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -141,14 +141,12 @@ pub fn mean_shell_spawning_time(
                 times_system.push(r.time_system);
             }
         }
-        if let Some(ref bar) = progress_bar {
-            bar.inc(1);
-        }
-    }
-    if let Some(ref bar) = progress_bar {
-        bar.finish_and_clear();
+
+        progress_bar.as_ref().map(|bar| bar.inc(1));
     }
 
+    progress_bar.as_ref().map(|bar| bar.finish_and_clear());
+    
     Ok(TimingResult {
         time_real: mean(&times_real),
         time_user: mean(&times_user),
@@ -239,13 +237,11 @@ pub fn run_benchmark(
                 options.failure_action,
                 None,
             )?;
-            if let Some(ref pbar) = progress_bar {
-                pbar.inc(1);
-            }
+            progress_bar.as_ref().map(|bar| bar.inc(1));
+    
         }
-        if let Some(ref bar) = progress_bar {
-            bar.finish_and_clear();
-        }
+        progress_bar.as_ref().map(|bar| bar.finish_and_clear());
+        
     }
 
     // Set up progress bar (and spinner for initial measurement)
@@ -304,11 +300,9 @@ pub fn run_benchmark(
     all_succeeded = all_succeeded && success;
 
     // Re-configure the progress bar
-    if let Some(ref bar) = progress_bar {
-        bar.set_length(count);
-        bar.inc(1);
-    }
-
+    progress_bar.as_ref().map(|bar| bar.set_length(count));
+    progress_bar.as_ref().map(|bar| bar.inc(1));
+    
     // Gather statistics
     for _ in 0..count_remaining {
         run_preparation_command(&options.shell, &prepare_cmd, options.show_output)?;
@@ -318,9 +312,7 @@ pub fn run_benchmark(
             format!("Current estimate: {}", mean.to_string().green())
         };
 
-        if let Some(ref bar) = progress_bar {
-            bar.set_message(&msg);
-        }
+        progress_bar.as_ref().map(|bar| bar.set_message(&msg));
 
         let (res, success) = time_shell_command(
             &options.shell,
@@ -336,13 +328,11 @@ pub fn run_benchmark(
 
         all_succeeded = all_succeeded && success;
 
-        if let Some(ref bar) = progress_bar {
-            bar.inc(1);
-        }
+        progress_bar.as_ref().map(|bar| bar.inc(1));
     }
-    if let Some(ref bar) = progress_bar {
-        bar.finish_and_clear();
-    }
+
+    progress_bar.as_ref().map(|bar| bar.finish_and_clear());
+
 
     // Compute statistical quantities
     let t_num = times_real.len();

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -5,8 +5,6 @@ use std::process::Stdio;
 use colored::*;
 use statistical::{mean, median, standard_deviation};
 
-use indicatif::{ProgressBar};
-
 use crate::hyperfine::format::{format_duration, format_duration_unit};
 use crate::hyperfine::internal::{get_progress_bar, max, min, MIN_EXECUTION_TIME};
 use crate::hyperfine::outlier_detection::{modified_zscores, OUTLIER_THRESHOLD};
@@ -96,10 +94,15 @@ pub fn mean_shell_spawning_time(
     show_output: bool,
 ) -> io::Result<TimingResult> {
     const COUNT: u64 = 200;
-    let mut progress_bar: Option<ProgressBar> = None;
-    if style != OutputStyleOption::None { 
-        progress_bar = Some(get_progress_bar(COUNT, "Measuring shell spawning time", style)); 
-    }
+    let progress_bar = if style != OutputStyleOption::Disabled {
+        Some(get_progress_bar(
+            COUNT,
+            "Measuring shell spawning time",
+            style,
+        ))
+    } else {
+        None
+    };
 
     let mut times_real: Vec<Second> = vec![];
     let mut times_user: Vec<Second> = vec![];
@@ -137,10 +140,14 @@ pub fn mean_shell_spawning_time(
                 times_user.push(r.time_user);
                 times_system.push(r.time_system);
             }
-        }  
-        // if let Some(bar) = progress_bar { bar.inc(1); }
+        }
+        if let Some(ref bar) = progress_bar {
+            bar.inc(1);
+        }
     }
-    if let Some(bar) = progress_bar { bar.finish_and_clear(); }
+    if let Some(ref bar) = progress_bar {
+        bar.finish_and_clear();
+    }
 
     Ok(TimingResult {
         time_real: mean(&times_real),
@@ -198,7 +205,7 @@ pub fn run_benchmark(
     shell_spawning_time: TimingResult,
     options: &HyperfineOptions,
 ) -> io::Result<BenchmarkResult> {
-    if options.output_style != OutputStyleOption::None { 
+    if options.output_style != OutputStyleOption::Disabled {
         println!(
             "{}{}: {}",
             "Benchmark #".bold(),
@@ -214,14 +221,15 @@ pub fn run_benchmark(
 
     // Warmup phase
     if options.warmup_count > 0 {
-        let mut progress_bar: Option<ProgressBar> = None;
-        if options.output_style != OutputStyleOption::None { 
-                progress_bar = Some(get_progress_bar(
+        let progress_bar = if options.output_style != OutputStyleOption::Disabled {
+            Some(get_progress_bar(
                 options.warmup_count,
                 "Performing warmup runs",
                 options.output_style,
-            ));
-        }
+            ))
+        } else {
+            None
+        };
 
         for _ in 0..options.warmup_count {
             let _ = time_shell_command(
@@ -231,21 +239,25 @@ pub fn run_benchmark(
                 options.failure_action,
                 None,
             )?;
-            if let Some(pbar) = progress_bar.clone() { pbar.inc(1); }
+            if let Some(ref pbar) = progress_bar {
+                pbar.inc(1);
+            }
         }
-        if let Some(bar) = progress_bar { bar.finish_and_clear(); }
+        if let Some(ref bar) = progress_bar {
+            bar.finish_and_clear();
+        }
     }
 
     // Set up progress bar (and spinner for initial measurement)
-    let mut progress_bar:Option<ProgressBar> = None;
-
-    if options.output_style != OutputStyleOption::None { 
-            progress_bar = Some(get_progress_bar(
+    let progress_bar = if options.output_style != OutputStyleOption::Disabled {
+        Some(get_progress_bar(
             options.runs.min,
             "Initial time measurement",
             options.output_style,
         ))
-    }
+    } else {
+        None
+    };
 
     // Run init command
     let prepare_cmd = options
@@ -292,8 +304,10 @@ pub fn run_benchmark(
     all_succeeded = all_succeeded && success;
 
     // Re-configure the progress bar
-    if let Some(bar) = progress_bar.clone() { bar.set_length(count); }
-    if let Some(bar) = progress_bar.clone() { bar.inc(1); }
+    if let Some(ref bar) = progress_bar {
+        bar.set_length(count);
+        bar.inc(1);
+    }
 
     // Gather statistics
     for _ in 0..count_remaining {
@@ -304,7 +318,9 @@ pub fn run_benchmark(
             format!("Current estimate: {}", mean.to_string().green())
         };
 
-        if let Some(bar) = progress_bar.clone() { bar.set_message(&msg); }
+        if let Some(ref bar) = progress_bar {
+            bar.set_message(&msg);
+        }
 
         let (res, success) = time_shell_command(
             &options.shell,
@@ -320,9 +336,13 @@ pub fn run_benchmark(
 
         all_succeeded = all_succeeded && success;
 
-        if let Some(bar) = progress_bar.clone() { bar.inc(1); }
+        if let Some(ref bar) = progress_bar {
+            bar.inc(1);
+        }
     }
-    if let Some(bar) = progress_bar { bar.finish_and_clear(); }
+    if let Some(ref bar) = progress_bar {
+        bar.finish_and_clear();
+    }
 
     // Compute statistical quantities
     let t_num = times_real.len();
@@ -345,7 +365,7 @@ pub fn run_benchmark(
     let (user_str, user_unit) = format_duration_unit(user_mean, None);
     let system_str = format_duration(system_mean, Some(user_unit));
 
-    if options.output_style != OutputStyleOption::None {
+    if options.output_style != OutputStyleOption::Disabled {
         println!(
             "  Time ({} ± {}):     {:>8} ± {:>8}    [User: {}, System: {}]",
             "mean".green().bold(),
@@ -387,7 +407,7 @@ pub fn run_benchmark(
         warnings.push(Warnings::OutliersDetected);
     }
 
-    if !warnings.is_empty() && options.output_style != OutputStyleOption::None {
+    if !warnings.is_empty() {
         eprintln!(" ");
 
         for warning in &warnings {
@@ -395,7 +415,9 @@ pub fn run_benchmark(
         }
     }
 
-    if options.output_style != OutputStyleOption::None { println!(" "); }
+    if options.output_style != OutputStyleOption::Disabled {
+        println!(" ");
+    }
 
     // Run cleanup command
     let cleanup_cmd =

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -115,7 +115,7 @@ pub enum OutputStyleOption {
     Color,
 
     /// Disable all the output
-    None,
+    Disabled,
 }
 
 /// Number of runs for a benchmark

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -113,6 +113,9 @@ pub enum OutputStyleOption {
 
     /// Keep coloring, but use no progress bar
     Color,
+
+    /// Disable all the output
+    None,
 }
 
 /// Number of runs for a benchmark

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,13 @@ fn main() {
 
     match res {
         Ok(timing_results) => {
-            let unwrapped = options.unwrap();
-            if unwrapped.output_style != OutputStyleOption::None { write_benchmark_comparison(&timing_results); }
-            let ans = export_manager.write_results(timing_results, unwrapped.time_unit);
+            let options = options.unwrap();
+
+            if options.output_style != OutputStyleOption::Disabled {
+                write_benchmark_comparison(&timing_results);
+            }
+
+            let ans = export_manager.write_results(timing_results, options.time_unit);
             if let Err(e) = ans {
                 error(&format!(
                     "The following error occurred while exporting: {}",
@@ -125,7 +129,7 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
         Some("basic") => OutputStyleOption::Basic,
         Some("nocolor") => OutputStyleOption::NoColor,
         Some("color") => OutputStyleOption::Color,
-        Some("none") => OutputStyleOption::None,
+        Some("none") => OutputStyleOption::Disabled,
         _ => {
             if !options.show_output && atty::is(Stream::Stdout) {
                 OutputStyleOption::Full

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
     let options = build_hyperfine_options(&matches);
     let export_manager = build_export_manager(&matches);
     let commands = build_commands(&matches);
+    let unwrapped_opts = options.unwrap();
 
     let res = match options {
         Ok(ref opts) => run(&commands, &opts),
@@ -54,8 +55,8 @@ fn main() {
 
     match res {
         Ok(timing_results) => {
-            write_benchmark_comparison(&timing_results);
-            let ans = export_manager.write_results(timing_results, options.unwrap().time_unit);
+            if unwrapped_opts.output_style != OutputStyleOption::None { write_benchmark_comparison(&timing_results); }
+            let ans = export_manager.write_results(timing_results, unwrapped_opts.time_unit);
             if let Err(e) = ans {
                 error(&format!(
                     "The following error occurred while exporting: {}",
@@ -124,6 +125,7 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
         Some("basic") => OutputStyleOption::Basic,
         Some("nocolor") => OutputStyleOption::NoColor,
         Some("color") => OutputStyleOption::Color,
+        Some("none") => OutputStyleOption::None,
         _ => {
             if !options.show_output && atty::is(Stream::Stdout) {
                 OutputStyleOption::Full

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ fn main() {
     let options = build_hyperfine_options(&matches);
     let export_manager = build_export_manager(&matches);
     let commands = build_commands(&matches);
-    let unwrapped_opts = options.unwrap();
 
     let res = match options {
         Ok(ref opts) => run(&commands, &opts),
@@ -55,8 +54,9 @@ fn main() {
 
     match res {
         Ok(timing_results) => {
-            if unwrapped_opts.output_style != OutputStyleOption::None { write_benchmark_comparison(&timing_results); }
-            let ans = export_manager.write_results(timing_results, unwrapped_opts.time_unit);
+            let unwrapped = options.unwrap();
+            if unwrapped.output_style != OutputStyleOption::None { write_benchmark_comparison(&timing_results); }
+            let ans = export_manager.write_results(timing_results, unwrapped.time_unit);
             if let Err(e) = ans {
                 error(&format!(
                     "The following error occurred while exporting: {}",


### PR DESCRIPTION
This PR addresses the #193 Feature request. It allows to pass `none` as a value for `--style` option. 

If it is used, then no output (unless they are errors).

@sharkdp , may be there is some sense to print warnings as well. What do you think?
