### PR TITLE
Add relative speed to markdown export, closes #225

### DIFF
--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -53,16 +53,18 @@ fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResultWithRelativeSpeed, u
     let min_str = format_duration_value(result.min, Some(unit)).0;
     let max_str = format_duration_value(result.max, Some(unit)).0;
     let rel_str = format!("{:.2}", entry.relative_speed);
+    let rel_stddev_str = format!("{:.2}", entry.relative_speed_stddev);
 
     dest.extend(
         format!(
-            "| `{command}` | {mean} ± {stddev} | {min} | {max} | {rel} |\n",
+            "| `{command}` | {mean} ± {stddev} | {min} | {max} | {rel} ± {rel_stddev} |\n",
             command = result.command.replace("|", "\\|"),
             mean = mean_str,
             stddev = stddev_str,
             min = min_str,
             max = max_str,
             rel = rel_str,
+            rel_stddev = rel_stddev_str,
         )
         .as_bytes(),
     );
@@ -110,8 +112,8 @@ fn test_markdown_format_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 |
-| `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 18.97 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 ± 0.02 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 18.97 ± 0.29 |
 ",
         table_header("ms".to_string())
     );
@@ -157,8 +159,8 @@ fn test_markdown_format_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 18.97 |
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 |
+| `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 18.97 ± 0.29 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 ± 0.02 |
 ",
         table_header("s".to_string())
     );
@@ -208,8 +210,8 @@ fn test_markdown_format_time_unit_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 |
-| `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 18.97 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 ± 0.02 |
+| `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 18.97 ± 0.29 |
 ",
         table_header("s".to_string())
     );
@@ -260,8 +262,8 @@ fn test_markdown_format_time_unit_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 18.97 |
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 |
+| `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 18.97 ± 0.29 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 ± 0.02 |
 ",
         table_header("ms".to_string())
     );

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -53,11 +53,15 @@ fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResultWithRelativeSpeed, u
     let min_str = format_duration_value(result.min, Some(unit)).0;
     let max_str = format_duration_value(result.max, Some(unit)).0;
     let rel_str = format!("{:.2}", entry.relative_speed);
-    let rel_stddev_str = format!("{:.2}", entry.relative_speed_stddev);
+    let rel_stddev_str = if entry.is_fastest {
+        "".into()
+    } else {
+        format!(" ± {:.2}", entry.relative_speed_stddev)
+    };
 
     dest.extend(
         format!(
-            "| `{command}` | {mean} ± {stddev} | {min} | {max} | {rel} ± {rel_stddev} |\n",
+            "| `{command}` | {mean} ± {stddev} | {min} | {max} | {rel}{rel_stddev} |\n",
             command = result.command.replace("|", "\\|"),
             mean = mean_str,
             stddev = stddev_str,
@@ -112,7 +116,7 @@ fn test_markdown_format_ms() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 ± 0.02 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 |
 | `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 18.97 ± 0.29 |
 ",
         table_header("ms".to_string())
@@ -160,7 +164,7 @@ fn test_markdown_format_s() {
     let formatted_expected = format!(
         "{}\
 | `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 18.97 ± 0.29 |
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 ± 0.02 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 |
 ",
         table_header("s".to_string())
     );
@@ -210,7 +214,7 @@ fn test_markdown_format_time_unit_s() {
 
     let formatted_expected = format!(
         "{}\
-| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 ± 0.02 |
+| `sleep 0.1` | 0.106 ± 0.002 | 0.102 | 0.108 | 1.00 |
 | `sleep 2` | 2.005 ± 0.002 | 2.002 | 2.008 | 18.97 ± 0.29 |
 ",
         table_header("s".to_string())
@@ -263,7 +267,7 @@ fn test_markdown_format_time_unit_ms() {
     let formatted_expected = format!(
         "{}\
 | `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 18.97 ± 0.29 |
-| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 ± 0.02 |
+| `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 1.00 |
 ",
         table_header("ms".to_string())
     );

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -50,6 +50,7 @@ pub struct BenchmarkResultWithRelativeSpeed<'a> {
     pub result: &'a BenchmarkResult,
     pub relative_speed: Scalar,
     pub relative_speed_stddev: Scalar,
+    pub is_fastest: bool,
 }
 
 fn compare_mean_time(l: &BenchmarkResult, r: &BenchmarkResult) -> Ordering {
@@ -79,6 +80,7 @@ pub fn compute_relative_speed<'a>(
                 result,
                 relative_speed: ratio,
                 relative_speed_stddev: ratio_stddev,
+                is_fastest: result == fastest,
             }
         })
         .collect()

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_SHELL: &str = "sh";
 #[cfg(windows)]
 pub const DEFAULT_SHELL: &str = "cmd.exe";
 
-#[derive(Debug, Clone, Serialize, Copy)]
+#[derive(Debug, Clone, Serialize, Copy, PartialEq)]
 #[serde(untagged)]
 pub enum NumericType {
     Int(i32),
@@ -181,7 +181,7 @@ impl Default for HyperfineOptions {
 }
 
 /// Set of values that will be exported.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, PartialEq)]
 pub struct BenchmarkResult {
     /// The command that was run
     pub command: String,


### PR DESCRIPTION
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `fd -e jpg . ~` | 209.0 ± 11.6 | 201.6 | 241.7 | 1.00 |
| `find ~ -iname "*.jpg"` | 2730.6 ± 80.5 | 2564.6 | 2807.7 | 13.06 ± 0.82 |
