### PR TITLE
Add --parameter-list option

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -140,8 +140,8 @@ fn build_app() -> App<'static, 'static> {
                 .help(
                     "Perform benchmark runs for each value in the comma-seperated list VALUES. \
                      Replaces the string '{VAR}' in each command by the current parameter value\
-                     .\n\nExample:  hyperfine -L threads 1,2,4 'make -j {threads}'\n\n\
-                     This performs benchmarks for 'make -j 1', 'make -j 2', and 'make -j 4'.",
+                     .\n\nExample:  hyperfine -L compiler gcc,clang '{compiler} -O2 main.cpp'\n\n\
+                     This performs benchmarks for 'gcc -O2 main.cpp' and 'clang -O2 main.cpp'.",
                 ),
         )
         .arg(

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -136,7 +136,7 @@ fn build_app() -> App<'static, 'static> {
                 .takes_value(true)
                 .allow_hyphen_values(true)
                 .value_names(&["VAR", "VALUES"])
-                .conflicts_with("parameter-scan")
+                .conflicts_with_all(&["parameter-scan", "parameter-step-size"])
                 .help(
                     "Perform benchmark runs for each value in the comma-seperated list VALUES. \
                      Replaces the string '{VAR}' in each command by the current parameter value\

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -130,6 +130,21 @@ fn build_app() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("parameter-list")
+                .long("parameter-list")
+                .short("L")
+                .takes_value(true)
+                .allow_hyphen_values(true)
+                .value_names(&["VAR", "VALUES"])
+                .conflicts_with("parameter-scan")
+                .help(
+                    "Perform benchmark runs for each value in the comma-seperated list VALUES. \
+                     Replaces the string '{VAR}' in each command by the current parameter value\
+                     .\n\nExample:  hyperfine -L threads 1,2,4 'make -j {threads}'\n\n\
+                     This performs benchmarks for 'make -j 1', 'make -j 2', and 'make -j 4'.",
+                ),
+        )
+        .arg(
             Arg::with_name("style")
                 .long("style")
                 .short("s")

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -225,7 +225,7 @@ pub fn run_benchmark(
             &values[num]
         };
         match cmd.get_parameter() {
-            Some((param, value)) => Command::new_parametrized(preparation_command, param, value),
+            Some((param, value)) => Command::new_parametrized(preparation_command, param, value.clone()),
             None => Command::new(preparation_command),
         }
     });
@@ -421,7 +421,7 @@ pub fn run_benchmark(
             .cleanup_command
             .as_ref()
             .map(|cleanup_command| match cmd.get_parameter() {
-                Some((param, value)) => Command::new_parametrized(cleanup_command, param, value),
+                Some((param, value)) => Command::new_parametrized(cleanup_command, param, value.clone()),
                 None => Command::new(cleanup_command),
             });
     run_cleanup_command(&options.shell, &cleanup_cmd, options.show_output)?;
@@ -436,6 +436,6 @@ pub fn run_benchmark(
         t_min,
         t_max,
         times_real,
-        cmd.get_parameter().map(|p| p.1),
+        cmd.get_parameter().as_ref().map(|p| p.1.clone()),
     ))
 }

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -146,7 +146,7 @@ pub fn mean_shell_spawning_time(
     }
 
     progress_bar.as_ref().map(|bar| bar.finish_and_clear());
-    
+
     Ok(TimingResult {
         time_real: mean(&times_real),
         time_user: mean(&times_user),
@@ -225,7 +225,7 @@ pub fn run_benchmark(
             &values[num]
         };
         match cmd.get_parameter() {
-            Some((param, value)) => Command::new_parametrized(preparation_command, param, value.clone()),
+            Some((param, value)) => Command::new_parametrized(preparation_command, param, *value),
             None => Command::new(preparation_command),
         }
     });
@@ -252,10 +252,8 @@ pub fn run_benchmark(
                 None,
             )?;
             progress_bar.as_ref().map(|bar| bar.inc(1));
-    
         }
         progress_bar.as_ref().map(|bar| bar.finish_and_clear());
-        
     }
 
     // Set up progress bar (and spinner for initial measurement)
@@ -308,7 +306,7 @@ pub fn run_benchmark(
     // Re-configure the progress bar
     progress_bar.as_ref().map(|bar| bar.set_length(count));
     progress_bar.as_ref().map(|bar| bar.inc(1));
-    
+
     // Gather statistics
     for _ in 0..count_remaining {
         run_preparation_command(&options.shell, &prepare_cmd, options.show_output)?;
@@ -338,7 +336,6 @@ pub fn run_benchmark(
     }
 
     progress_bar.as_ref().map(|bar| bar.finish_and_clear());
-
 
     // Compute statistical quantities
     let t_num = times_real.len();
@@ -421,7 +418,7 @@ pub fn run_benchmark(
             .cleanup_command
             .as_ref()
             .map(|cleanup_command| match cmd.get_parameter() {
-                Some((param, value)) => Command::new_parametrized(cleanup_command, param, value.clone()),
+                Some((param, value)) => Command::new_parametrized(cleanup_command, param, *value),
                 None => Command::new(cleanup_command),
             });
     run_cleanup_command(&options.shell, &cleanup_cmd, options.show_output)?;
@@ -436,6 +433,6 @@ pub fn run_benchmark(
         t_min,
         t_max,
         times_real,
-        cmd.get_parameter().as_ref().map(|p| p.1.clone()),
+        cmd.get_parameter().map(|p| p.1.to_string()),
     ))
 }

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -225,7 +225,9 @@ pub fn run_benchmark(
             &values[num]
         };
         match cmd.get_parameter() {
-            Some((param, value)) => Command::new_parametrized(preparation_command, param, *value),
+            Some((param, value)) => {
+                Command::new_parametrized(preparation_command, param, value.clone())
+            }
             None => Command::new(preparation_command),
         }
     });
@@ -418,7 +420,9 @@ pub fn run_benchmark(
             .cleanup_command
             .as_ref()
             .map(|cleanup_command| match cmd.get_parameter() {
-                Some((param, value)) => Command::new_parametrized(cleanup_command, param, *value),
+                Some((param, value)) => {
+                    Command::new_parametrized(cleanup_command, param, value.clone())
+                }
                 None => Command::new(cleanup_command),
             });
     run_cleanup_command(&options.shell, &cleanup_cmd, options.show_output)?;
@@ -433,6 +437,6 @@ pub fn run_benchmark(
         t_min,
         t_max,
         times_real,
-        cmd.get_parameter().map(|p| p.1.to_string()),
+        cmd.get_parameter().as_ref().map(|p| p.1.to_string()),
     ))
 }

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -150,10 +150,6 @@ fn test_compute_relative_speed() {
 }
 
 pub fn tokenize<'a>(values: &'a str) -> Vec<String> {
-    if values == "" {
-        return vec![];
-    }
-
     let mut tokens = vec![];
     let mut buf = String::new();
 
@@ -186,12 +182,8 @@ pub fn tokenize<'a>(values: &'a str) -> Vec<String> {
 }
 
 #[test]
-fn test_tokenize_empty() {
-    assert!(tokenize("").is_empty());
-}
-
-#[test]
 fn test_tokenize_single_value() {
+    assert_eq!(tokenize(r""), vec![""]);
     assert_eq!(tokenize(r"foo"), vec!["foo"]);
     assert_eq!(tokenize(r" "), vec![" "]);
     assert_eq!(tokenize(r"hello\, world!"), vec!["hello, world!"]);

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -148,3 +148,72 @@ fn test_compute_relative_speed() {
     assert_relative_eq!(1.0, annotated_results[1].relative_speed);
     assert_relative_eq!(2.5, annotated_results[2].relative_speed);
 }
+
+pub fn tokenize<'a>(values: &'a str) -> Vec<String> {
+    if values == "" {
+        return vec![];
+    }
+
+    let mut tokens = vec![];
+    let mut buf = String::new();
+
+    let mut iter = values.chars();
+    while let Some(c) = iter.next() {
+        match c {
+            '\\' => match iter.next() {
+                Some(c2 @ ',') | Some(c2 @ '\\') => {
+                    buf.push(c2);
+                }
+                Some(c2) => {
+                    buf.push('\\');
+                    buf.push(c2);
+                }
+                None => buf.push('\\'),
+            },
+            ',' => {
+                tokens.push(buf);
+                buf = String::new();
+            }
+            _ => {
+                buf.push(c);
+            }
+        };
+    }
+
+    tokens.push(buf);
+
+    tokens
+}
+
+#[test]
+fn test_tokenize_empty() {
+    assert!(tokenize("").is_empty());
+}
+
+#[test]
+fn test_tokenize_single_value() {
+    assert_eq!(tokenize(r"foo"), vec!["foo"]);
+    assert_eq!(tokenize(r" "), vec![" "]);
+    assert_eq!(tokenize(r"hello\, world!"), vec!["hello, world!"]);
+    assert_eq!(tokenize(r"\,"), vec![","]);
+    assert_eq!(tokenize(r"\,\,\,"), vec![",,,"]);
+    assert_eq!(tokenize(r"\n"), vec![r"\n"]);
+    assert_eq!(tokenize(r"\\"), vec![r"\"]);
+    assert_eq!(tokenize(r"\\\,"), vec![r"\,"]);
+}
+
+#[test]
+fn test_tokenize_multiple_values() {
+    assert_eq!(tokenize(r"foo,bar,baz"), vec!["foo", "bar", "baz"]);
+    assert_eq!(tokenize(r"hello world,foo"), vec!["hello world", "foo"]);
+
+    assert_eq!(tokenize(r"hello\,world!,baz"), vec!["hello,world!", "baz"]);
+}
+
+#[test]
+fn test_tokenize_empty_values() {
+    assert_eq!(tokenize(r"foo,,bar"), vec!["foo", "", "bar"]);
+    assert_eq!(tokenize(r",bar"), vec!["", "bar"]);
+    assert_eq!(tokenize(r"bar,"), vec!["bar", ""]);
+    assert_eq!(tokenize(r",,"), vec!["", "", ""]);
+}

--- a/src/hyperfine/parameter_range.rs
+++ b/src/hyperfine/parameter_range.rs
@@ -92,7 +92,7 @@ fn build_parameterized_commands<'a, T: Numeric>(
 
     for value in param_range {
         for cmd in &command_strings {
-            commands.push(Command::new_parametrized(cmd, param_name, value.into()));
+            commands.push(Command::new_parametrized(cmd, param_name, value.into().to_string()));
         }
     }
     Ok(commands)

--- a/src/hyperfine/parameter_range.rs
+++ b/src/hyperfine/parameter_range.rs
@@ -1,5 +1,5 @@
 use crate::hyperfine::error::ParameterScanError;
-use crate::hyperfine::types::{Command, NumericType};
+use crate::hyperfine::types::{Command, NumericType, ParameterValue};
 use clap::Values;
 use rust_decimal::Decimal;
 use std::ops::{Add, AddAssign, Div, Sub};
@@ -92,7 +92,11 @@ fn build_parameterized_commands<'a, T: Numeric>(
 
     for value in param_range {
         for cmd in &command_strings {
-            commands.push(Command::new_parametrized(cmd, param_name, value.into().to_string()));
+            commands.push(Command::new_parametrized(
+                cmd,
+                param_name,
+                ParameterValue::Numeric(value.into()),
+            ));
         }
     }
     Ok(commands)

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -39,6 +39,21 @@ impl Into<NumericType> for Decimal {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum ParameterValue<'a> {
+    Text(&'a str),
+    Numeric(NumericType),
+}
+
+impl<'a> ToString for ParameterValue<'a> {
+    fn to_string(&self) -> String {
+        match self {
+            ParameterValue::Text(value) => value.to_string(),
+            ParameterValue::Numeric(value) => value.to_string(),
+        }
+    }
+}
+
 /// A command that should be benchmarked.
 #[derive(Debug, Clone)]
 pub struct Command<'a> {
@@ -46,7 +61,7 @@ pub struct Command<'a> {
     expression: &'a str,
 
     /// A possible parameter value.
-    parameter: Option<(&'a str, String)>,
+    parameter: Option<(&'a str, ParameterValue<'a>)>,
 }
 
 impl<'a> Command<'a> {
@@ -60,7 +75,7 @@ impl<'a> Command<'a> {
     pub fn new_parametrized(
         expression: &'a str,
         parameter: &'a str,
-        value: String,
+        value: ParameterValue<'a>,
     ) -> Command<'a> {
         Command {
             expression,
@@ -78,7 +93,7 @@ impl<'a> Command<'a> {
         }
     }
 
-    pub fn get_parameter(&self) -> &Option<(&'a str, String)> {
+    pub fn get_parameter(&self) -> &Option<(&'a str, ParameterValue<'a>)> {
         &self.parameter
     }
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -39,16 +39,16 @@ impl Into<NumericType> for Decimal {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ParameterValue<'a> {
-    Text(&'a str),
+#[derive(Debug, Clone)]
+pub enum ParameterValue {
+    Text(String),
     Numeric(NumericType),
 }
 
-impl<'a> ToString for ParameterValue<'a> {
+impl<'a> ToString for ParameterValue {
     fn to_string(&self) -> String {
         match self {
-            ParameterValue::Text(value) => value.to_string(),
+            ParameterValue::Text(ref value) => value.clone(),
             ParameterValue::Numeric(value) => value.to_string(),
         }
     }
@@ -61,7 +61,7 @@ pub struct Command<'a> {
     expression: &'a str,
 
     /// A possible parameter value.
-    parameter: Option<(&'a str, ParameterValue<'a>)>,
+    parameter: Option<(&'a str, ParameterValue)>,
 }
 
 impl<'a> Command<'a> {
@@ -75,7 +75,7 @@ impl<'a> Command<'a> {
     pub fn new_parametrized(
         expression: &'a str,
         parameter: &'a str,
-        value: ParameterValue<'a>,
+        value: ParameterValue,
     ) -> Command<'a> {
         Command {
             expression,
@@ -93,7 +93,7 @@ impl<'a> Command<'a> {
         }
     }
 
-    pub fn get_parameter(&self) -> &Option<(&'a str, ParameterValue<'a>)> {
+    pub fn get_parameter(&self) -> &Option<(&'a str, ParameterValue)> {
         &self.parameter
     }
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -46,7 +46,7 @@ pub struct Command<'a> {
     expression: &'a str,
 
     /// A possible parameter value.
-    parameter: Option<(&'a str, NumericType)>,
+    parameter: Option<(&'a str, String)>,
 }
 
 impl<'a> Command<'a> {
@@ -60,7 +60,7 @@ impl<'a> Command<'a> {
     pub fn new_parametrized(
         expression: &'a str,
         parameter: &'a str,
-        value: NumericType,
+        value: String,
     ) -> Command<'a> {
         Command {
             expression,
@@ -69,7 +69,7 @@ impl<'a> Command<'a> {
     }
 
     pub fn get_shell_command(&self) -> String {
-        match self.parameter {
+        match &self.parameter {
             Some((param_name, param_value)) => self.expression.replace(
                 &format!("{{{param_name}}}", param_name = param_name),
                 &param_value.to_string(),
@@ -78,8 +78,8 @@ impl<'a> Command<'a> {
         }
     }
 
-    pub fn get_parameter(&self) -> Option<(&'a str, NumericType)> {
-        self.parameter
+    pub fn get_parameter(&self) -> &Option<(&'a str, String)> {
+        &self.parameter
     }
 }
 
@@ -216,7 +216,7 @@ pub struct BenchmarkResult {
 
     /// Any parameter used
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameter: Option<NumericType>,
+    pub parameter: Option<String>,
 }
 
 impl BenchmarkResult {
@@ -231,7 +231,7 @@ impl BenchmarkResult {
         min: Second,
         max: Second,
         times: Vec<Second>,
-        parameter: Option<NumericType>,
+        parameter: Option<String>,
     ) -> Self {
         BenchmarkResult {
             command,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::hyperfine::export::{ExportManager, ExportType};
 use crate::hyperfine::internal::write_benchmark_comparison;
 use crate::hyperfine::parameter_range::get_parameterized_commands;
 use crate::hyperfine::types::{
-    BenchmarkResult, CmdFailureAction, Command, HyperfineOptions, OutputStyleOption,
+    BenchmarkResult, CmdFailureAction, Command, HyperfineOptions, OutputStyleOption, ParameterValue,
 };
 use crate::hyperfine::units::Unit;
 
@@ -219,7 +219,11 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
 
         for value in param_list {
             for cmd in &command_list {
-                commands.push(Command::new_parametrized(cmd, param_name, value.to_string()));
+                commands.push(Command::new_parametrized(
+                    cmd,
+                    param_name,
+                    ParameterValue::Text(value),
+                ));
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,22 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
             Ok(commands) => commands,
             Err(e) => error(e.description()),
         }
+    } else if let Some(mut args) = matches.values_of("parameter-list") {
+        let param_name = args.next().unwrap();
+        let param_list_str = args.next().unwrap();
+
+        let param_list = param_list_str.split(',').collect::<Vec<&str>>();
+        let command_list = command_strings.collect::<Vec<&str>>();
+
+        let mut commands = Vec::with_capacity(param_list.len() * command_list.len());
+
+        for value in param_list {
+            for cmd in &command_list {
+                commands.push(Command::new_parametrized(cmd, param_name, value.to_string()));
+            }
+        }
+
+        commands
     } else {
         command_strings.map(Command::new).collect()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use crate::hyperfine::app::get_arg_matches;
 use crate::hyperfine::benchmark::{mean_shell_spawning_time, run_benchmark};
 use crate::hyperfine::error::OptionsError;
 use crate::hyperfine::export::{ExportManager, ExportType};
-use crate::hyperfine::internal::write_benchmark_comparison;
+use crate::hyperfine::internal::{tokenize, write_benchmark_comparison};
 use crate::hyperfine::parameter_range::get_parameterized_commands;
 use crate::hyperfine::types::{
     BenchmarkResult, CmdFailureAction, Command, HyperfineOptions, OutputStyleOption, ParameterValue,
@@ -212,7 +212,7 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
         let param_name = args.next().unwrap();
         let param_list_str = args.next().unwrap();
 
-        let param_list = param_list_str.split(',').collect::<Vec<&str>>();
+        let param_list = tokenize(param_list_str);
         let command_list = command_strings.collect::<Vec<&str>>();
 
         let mut commands = Vec::with_capacity(param_list.len() * command_list.len());
@@ -222,7 +222,7 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
                 commands.push(Command::new_parametrized(
                     cmd,
                     param_name,
-                    ParameterValue::Text(value),
+                    ParameterValue::Text(value.clone()),
                 ));
             }
         }


### PR DESCRIPTION
This currently only splits the `VALUES` string on commas and doesn't try to do anything to support elements with commas in them. I couldn't find anything in clap that would support automatically parsing a list.

Closes #227