### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -27,26 +27,23 @@ impl From<DecimalError> for ParameterScanError {
 
 impl fmt::Display for ParameterScanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl Error for ParameterScanError {
-    fn description(&self) -> &str {
         match *self {
-            ParameterScanError::ParseIntError(ref e) => e.description(),
-            ParameterScanError::ParseDecimalError(ref e) => e.description(),
-            ParameterScanError::EmptyRange => "Empty parameter range",
-            ParameterScanError::TooLarge => "Parameter range is too large",
-            ParameterScanError::ZeroStep => "Zero is not a valid parameter step",
-            ParameterScanError::StepRequired => {
+            ParameterScanError::ParseIntError(ref e) => write!(f, "{}", e),
+            ParameterScanError::ParseDecimalError(ref e) => write!(f, "{}", e),
+            ParameterScanError::EmptyRange => write!(f, "Empty parameter range"),
+            ParameterScanError::TooLarge => write!(f, "Parameter range is too large"),
+            ParameterScanError::ZeroStep => write!(f, "Zero is not a valid parameter step"),
+            ParameterScanError::StepRequired => write!(
+                f,
                 "A step size is required when the range bounds are \
                  floating point numbers. The step size can be specified \
                  with the '--parameter-step-size' parameter"
-            }
+            ),
         }
     }
 }
+
+impl Error for ParameterScanError {}
 
 #[derive(Debug)]
 pub enum OptionsError {
@@ -56,15 +53,11 @@ pub enum OptionsError {
 
 impl fmt::Display for OptionsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl Error for OptionsError {
-    fn description(&self) -> &str {
         match *self {
-            OptionsError::EmptyRunsRange => "Empty runs range",
-            OptionsError::RunsBelowTwo => "Number of runs below two",
+            OptionsError::EmptyRunsRange => write!(f, "Empty runs range"),
+            OptionsError::RunsBelowTwo => write!(f, "Number of runs below two"),
         }
     }
 }
+
+impl Error for OptionsError {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::cmp;
 use std::env;
-use std::error::Error;
 use std::io;
 
 use atty::Stream;
@@ -58,7 +57,7 @@ fn main() {
 
     let res = match options {
         Ok(ref opts) => run(&commands, &opts),
-        Err(ref e) => error(e.description()),
+        Err(ref e) => error(&e.to_string()),
     };
 
     match res {
@@ -73,11 +72,11 @@ fn main() {
             if let Err(e) = ans {
                 error(&format!(
                     "The following error occurred while exporting: {}",
-                    e.description()
+                    e
                 ));
             }
         }
-        Err(e) => error(e.description()),
+        Err(e) => error(&e.to_string()),
     }
 }
 
@@ -206,7 +205,7 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
         let step_size = matches.value_of("parameter-step-size");
         match get_parameterized_commands(command_strings, args, step_size) {
             Ok(commands) => commands,
-            Err(e) => error(e.description()),
+            Err(e) => error(&e.to_string()),
         }
     } else if let Some(mut args) = matches.values_of("parameter-list") {
         let param_name = args.next().unwrap();


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes an implementation of `description` in all error types
- Replaces all `description` usage

Related PR: https://github.com/rust-lang/rust/pull/66919