### PR TITLE
README: add instructions on installing via MacPorts for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Hyperfine can be installed via [Homebrew](https://brew.sh):
 brew install hyperfine
 ```
 
+Or you can install using [MacPorts](https://www.macports.org):
+```
+sudo port selfupdate
+sudo port install hyperfine
+```
+
 ### On FreeBSD
 
 Hyperfine can be installed via pkg:


### PR DESCRIPTION
First off, thank you for `hyperfine` - it's extremely useful and a very nice utility.
It's been added to [MacPorts](https://www.macports.org), so just adding instructions on installing via that method.