### PR TITLE
Option to use as a simple command timer

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -216,7 +216,6 @@ fn build_app() -> App<'static, 'static> {
         .arg(
             Arg::with_name("show-output")
                 .long("show-output")
-                .conflicts_with("style")
                 .help(
                     "Print the stdout and stderr of the benchmark instead of suppressing it. \
                      This will increase the time it takes for benchmarks to run, \

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -342,7 +342,11 @@ pub fn run_benchmark(
     // Compute statistical quantities
     let t_num = times_real.len();
     let t_mean = mean(&times_real);
-    let t_stddev = standard_deviation(&times_real, Some(t_mean));
+    let t_stddev = if times_real.len() > 1 {
+        standard_deviation(&times_real, Some(t_mean))
+    } else {
+        0.0
+    };
     let t_median = median(&times_real);
     let t_min = min(&times_real);
     let t_max = max(&times_real);

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -47,7 +47,6 @@ impl Error for ParameterScanError {}
 
 #[derive(Debug)]
 pub enum OptionsError {
-    RunsBelowTwo,
     EmptyRunsRange,
 }
 
@@ -55,7 +54,6 @@ impl fmt::Display for OptionsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             OptionsError::EmptyRunsRange => write!(f, "Empty runs range"),
-            OptionsError::RunsBelowTwo => write!(f, "Number of runs below two"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,16 +100,8 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
     }
 
     match (min_runs, max_runs) {
-        (Some(min), _) if min < 2 => {
-            // We need at least two runs to compute a variance.
-            return Err(OptionsError::RunsBelowTwo);
-        }
         (Some(min), None) => {
             options.runs.min = min;
-        }
-        (_, Some(max)) if max < 2 => {
-            // We need at least two runs to compute a variance.
-            return Err(OptionsError::RunsBelowTwo);
         }
         (None, Some(max)) => {
             // Since the minimum was not explicit we lower it if max is below the default min.


### PR DESCRIPTION
Initial attempt at implementing #276. This is my first attempt at working with Rust, so pardon any beginner mistakes. :)

Rather than adding a "hidden" `-t, --time` option, I simply made it possible to set `--runs=1` by setting a default standard deviation of `0.0` when doing single runs. The error from the statistical library is to prevent the sample standard deviation formula's `N-1` denominator from attempting a divide by zero (which I assume is why `runs` originally had to be `>=2`). This makes sense when benchmarking, as we are not sampling the *entire* population. In the case of `--runs=1`, we're just measuring the time it took the command to execute once. We aren't trying to infer anything about the population, and a standard deviation of `0.0` when all data points (in this case, just one of them) have the same value is valid.

**Example usage below:**

![image](https://user-images.githubusercontent.com/183833/78519548-be9aca00-7791-11ea-89c5-7ae0a0bfbfa2.png)

As for the following comment regarding mixing `--show-output` and `--style`...

> "I think that's actually overly restrictive. What we originally wanted (if I remember correctly) was to disable the interactive components (the progress bar and spinner). Colorized output (`--style=color` instead of `--style=full`) should be fine. Maybe we can change that."

I changed it so that `--style` and `--show-output` no longer conflict, but I wasn't clear if any other special handling was needed. Is this fine, or should `--show-output` still conflict with `--style=full`?