### PR TITLE
Use clap to generate shell completions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/sharkdp/hyperfine"
 version = "1.9.0"
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 colored = "1.9"
@@ -34,6 +35,11 @@ features = ["suggestions", "color", "wrap_help"]
 
 [dev-dependencies]
 approx = "0.3"
+
+[build-dependencies]
+clap = "2"
+version_check = "0.9"
+atty = "0.2"
 
 [profile.release]
 lto = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+use std::fs;
+
+use clap::Shell;
+
+include!("src/hyperfine/app.rs");
+
+fn main() {
+    let min_version = "1.39";
+
+    match version_check::is_min_version(min_version) {
+        Some(true) => {}
+        // rustc version too small or can't figure it out
+        _ => {
+            eprintln!("'hyperfine' requires rustc >= {}", min_version);
+            std::process::exit(1);
+        }
+    }
+
+    let var = std::env::var_os("SHELL_COMPLETIONS_DIR").or(std::env::var_os("OUT_DIR"));
+    let outdir = match var {
+        None => return,
+        Some(outdir) => outdir,
+    };
+    fs::create_dir_all(&outdir).unwrap();
+
+    let mut app = build_app();
+    app.gen_completions("hyperfine", Shell::Bash, &outdir);
+    app.gen_completions("hyperfine", Shell::Fish, &outdir);
+    app.gen_completions("hyperfine", Shell::Zsh, &outdir);
+    app.gen_completions("hyperfine", Shell::PowerShell, &outdir);
+}

--- a/ci/before_deploy.bash
+++ b/ci/before_deploy.bash
@@ -29,7 +29,8 @@ pack() {
     cp LICENSE-MIT "$tempdir/$package_name"
     cp LICENSE-APACHE "$tempdir/$package_name"
 
-     # various autocomplete
+    # various autocomplete
+    mkdir "$tempdir/$package_name/autocomplete"
     cp target/"$TARGET"/release/build/"$PROJECT_NAME"-*/out/"$PROJECT_NAME".bash "$tempdir/$package_name/autocomplete/${PROJECT_NAME}.bash-completion"
     cp target/"$TARGET"/release/build/"$PROJECT_NAME"-*/out/"$PROJECT_NAME".fish "$tempdir/$package_name/autocomplete"
     cp target/"$TARGET"/release/build/"$PROJECT_NAME"-*/out/_"$PROJECT_NAME" "$tempdir/$package_name/autocomplete"

--- a/ci/before_deploy.bash
+++ b/ci/before_deploy.bash
@@ -29,6 +29,11 @@ pack() {
     cp LICENSE-MIT "$tempdir/$package_name"
     cp LICENSE-APACHE "$tempdir/$package_name"
 
+     # various autocomplete
+    cp target/"$TARGET"/release/build/"$PROJECT_NAME"-*/out/"$PROJECT_NAME".bash "$tempdir/$package_name/autocomplete/${PROJECT_NAME}.bash-completion"
+    cp target/"$TARGET"/release/build/"$PROJECT_NAME"-*/out/"$PROJECT_NAME".fish "$tempdir/$package_name/autocomplete"
+    cp target/"$TARGET"/release/build/"$PROJECT_NAME"-*/out/_"$PROJECT_NAME" "$tempdir/$package_name/autocomplete"
+
     # archiving
     pushd "$tempdir"
     tar czf "$out_dir/$package_name.tar.gz" "$package_name"/*
@@ -78,6 +83,11 @@ make_deb() {
     install -Dm644 README.md "$tempdir/usr/share/doc/$PROJECT_NAME/README.md"
     install -Dm644 LICENSE-MIT "$tempdir/usr/share/doc/$PROJECT_NAME/LICENSE-MIT"
     install -Dm644 LICENSE-APACHE "$tempdir/usr/share/doc/$PROJECT_NAME/LICENSE-APACHE"
+
+    # completions
+    install -Dm644 target/$TARGET/release/build/$PROJECT_NAME-*/out/$PROJECT_NAME.bash "$tempdir/usr/share/bash-completion/completions/${PROJECT_NAME}"
+    install -Dm644 target/$TARGET/release/build/$PROJECT_NAME-*/out/$PROJECT_NAME.fish "$tempdir/usr/share/fish/completions/$PROJECT_NAME.fish"
+    install -Dm644 target/$TARGET/release/build/$PROJECT_NAME-*/out/_$PROJECT_NAME "$tempdir/usr/share/zsh/vendor-completions/_$PROJECT_NAME"
 
     # Control file
     mkdir "$tempdir/DEBIAN"


### PR DESCRIPTION
Re: #288 

Hopefully this is analogous to [sharkdp/fd#66](https://github.com/sharkdp/fd/pull/66). Changes to `ci/before_deploy.bash` mirror [sharkdp/fd](https://github.com/sharkdp/fd/blob/master/ci/before_deploy.bash) when copying shell completions across.

This is the first PR I've submitted with Rust -- still learning OSS and Rust, so any feedback and I'll fix up what I can.