### PR TITLE
Fix typo and case

### DIFF
--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -142,7 +142,7 @@ Set the time \fIunit\fP to be used. Default: second. Possible values: millisecon
 .HP
 \fB\-\-export\-asciidoc\fR \fIfile\fP 
 .IP
-Export the timing summary statistics as an Asciidoc table to the given \fIfile\fP.
+Export the timing summary statistics as an AsciiDoc table to the given \fIfile\fP.
 .HP
 \fB\-\-export\-csv\fR \fIfile\fP
 .IP

--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -107,7 +107,7 @@ This performs benchmarks for 'sleep 0.3', 'sleep 0.5' and 'sleep 0.7'.
 .HP
 \fB\-L\fR, \fB\-\-parameter\-list\fR \fIvar\fP \fIvalues\fP
 .IP
-Perform benchmark runs for each value in the comma\-seperated list of \fIvalues\fP.
+Perform benchmark runs for each value in the comma\-separated list of \fIvalues\fP.
 Replaces the string '{\fIvar\fP}' in each command by the current parameter value.
 .IP
 .RS

--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -205,7 +205,7 @@ Export the results of a parameter scan benchmark to a markdown table:
 .LP
 David Peter (sharkdp)
 .LP
-Source, bug tracker, and additional information can be found on Github at:
+Source, bug tracker, and additional information can be found on GitHub at:
 .\ We should use the URL macro here but it isn't supported on all platforms
 .\ .UR https://github.com/sharkdp/hyperfine
 .\ .UE

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -138,7 +138,7 @@ fn build_app() -> App<'static, 'static> {
                 .value_names(&["VAR", "VALUES"])
                 .conflicts_with_all(&["parameter-scan", "parameter-step-size"])
                 .help(
-                    "Perform benchmark runs for each value in the comma-seperated list VALUES. \
+                    "Perform benchmark runs for each value in the comma-separated list VALUES. \
                      Replaces the string '{VAR}' in each command by the current parameter value\
                      .\n\nExample:  hyperfine -L compiler gcc,clang '{compiler} -O2 main.cpp'\n\n\
                      This performs benchmarks for 'gcc -O2 main.cpp' and 'clang -O2 main.cpp'.",

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -189,7 +189,7 @@ fn build_app() -> App<'static, 'static> {
                 .long("export-asciidoc")
                 .takes_value(true)
                 .value_name("FILE")
-                .help("Export the timing summary statistics as an Asciidoc table to the given FILE."),
+                .help("Export the timing summary statistics as an AsciiDoc table to the given FILE."),
         )
         .arg(
             Arg::with_name("export-csv")


### PR DESCRIPTION
@sharkdp I love hyperfine, thanks a lot for making this tool!

While using it, I found a typo in the help ("seperated") and then found a few small casing issues ("AsciiDoc" and "GitHub") when fixing the typo.