### PR TITLE
Remove manpage comment

### DIFF
--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -206,7 +206,4 @@ Export the results of a parameter scan benchmark to a markdown table:
 David Peter (sharkdp)
 .LP
 Source, bug tracker, and additional information can be found on GitHub at:
-.\ We should use the URL macro here but it isn't supported on all platforms
-.\ .UR https://github.com/sharkdp/hyperfine
-.\ .UE
 .I https://github.com/sharkdp/hyperfine


### PR DESCRIPTION
The comment causes a syntax error when run with older versions of man (i.e. 1.6g on MacOS)