### PR TITLE
Feature/incremental export

### DIFF
--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -229,10 +229,8 @@ fn build_app() -> App<'static, 'static> {
                 .long("incremental-export")
                 .requires("export-csv")
                 .help(
-                    "Print the stdout and stderr of the benchmark instead of suppressing it. \
-                     This will increase the time it takes for benchmarks to run, \
-                     so it should only be used for debugging purposes or \
-                     when trying to benchmark output speed.",
+                    "Writes test results incrementally to a file after each test run \
+                    instead of waiting till all tests have finished.",
                 ),
         )
         .help_message("Print this help message.")

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -224,15 +224,6 @@ fn build_app() -> App<'static, 'static> {
                      when trying to benchmark output speed.",
                 ),
         )
-        .arg(
-            Arg::with_name("incremental-export")
-                .long("incremental-export")
-                .requires("export-csv")
-                .help(
-                    "Writes test results incrementally to a file after each test run \
-                    instead of waiting till all tests have finished.",
-                ),
-        )
         .help_message("Print this help message.")
         .version_message("Show version information.")
 }

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -224,6 +224,17 @@ fn build_app() -> App<'static, 'static> {
                      when trying to benchmark output speed.",
                 ),
         )
+        .arg(
+            Arg::with_name("incremental-export")
+                .long("incremental-export")
+                .requires("export-csv")
+                .help(
+                    "Print the stdout and stderr of the benchmark instead of suppressing it. \
+                     This will increase the time it takes for benchmarks to run, \
+                     so it should only be used for debugging purposes or \
+                     when trying to benchmark output speed.",
+                ),
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.")
 }

--- a/src/hyperfine/export/asciidoc.rs
+++ b/src/hyperfine/export/asciidoc.rs
@@ -35,7 +35,7 @@ impl Exporter for AsciidocExporter {
         Ok(res)
     }
     fn write_to_file_incremental(&mut self, _: &BenchmarkResult, _: Option<Unit>) -> Result<()> { 
-        todo!() 
+        Ok(())
     }
 }
 

--- a/src/hyperfine/export/asciidoc.rs
+++ b/src/hyperfine/export/asciidoc.rs
@@ -34,6 +34,9 @@ impl Exporter for AsciidocExporter {
 
         Ok(res)
     }
+    fn write_to_file_incremental(&mut self, _: &BenchmarkResult, _: Option<Unit>) -> Result<()> { 
+        todo!() 
+    }
 }
 
 fn table_open() -> Vec<u8> {

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -37,6 +37,9 @@ impl Exporter for CsvExporter {
         strip_times_and_write(&mut self.writer, result)?;
         self.writer.flush()
     }
+    fn supports_incremental_writes(&self) -> bool { 
+        true
+    }
 }
 
 fn strip_times_and_write(writer: &mut Writer<File>, result: &BenchmarkResult) -> Result<()> { 

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -1,28 +1,99 @@
+use std::fs::File;
 use super::Exporter;
 
 use crate::hyperfine::types::BenchmarkResult;
 use crate::hyperfine::units::Unit;
 
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind, Result, Read};
 
 use csv::WriterBuilder;
+use csv::Writer;
 
-#[derive(Default)]
-pub struct CsvExporter {}
-
+pub struct CsvExporter {
+    writer: Writer<File>
+}
+impl CsvExporter { 
+    pub fn new(filename: &str) -> Self { 
+        CsvExporter { 
+            writer: WriterBuilder::new().from_path(filename).unwrap()
+        }
+    }
+}
 impl Exporter for CsvExporter {
     fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
-        for res in results {
+        for result in results {
             // The list of times cannot be exported to the CSV file - remove it:
-            let mut result = res.clone();
+            let mut result = result.clone();
             result.times = None;
-
             writer.serialize(result)?;
         }
-
+        
         writer
             .into_inner()
             .map_err(|e| Error::new(ErrorKind::Other, e))
     }
+    fn write_to_file_incremental(&mut self, result: &BenchmarkResult, _unit: Option<Unit>) -> Result<()> { 
+        strip_times_and_write(&mut self.writer, result)?;
+        self.writer.flush()
+    }
+}
+
+fn strip_times_and_write(writer: &mut Writer<File>, result: &BenchmarkResult) -> Result<()> { 
+    // The list of times cannot be exported to the CSV file - remove it:
+    let mut result = result.clone();
+    result.times = None;
+    writer.serialize(result)
+        .map_err(|e| Error::new(ErrorKind::Other, e))
+}
+
+/// Integration test
+#[test]
+fn test_lines_are_appended() { 
+    let path = &String::from("incremental.csv");
+    let mut exporter = CsvExporter::new(path);
+    
+    let results = vec![
+        BenchmarkResult::new(
+            String::from("command | 1"),
+            1.0,
+            2.0,
+            1.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            vec![7.0, 8.0, 9.0],
+            None,
+        ),
+        BenchmarkResult::new(
+            String::from("command | 2"),
+            11.0,
+            12.0,
+            11.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+            vec![17.0, 18.0, 19.0],
+            None,
+        ),
+    ];
+
+    for mut result in results {
+        exporter.write_to_file_incremental(&mut result, Some(Unit::Second)).unwrap();
+        let metadata = std::fs::metadata(path).unwrap();
+        println!("{}b", metadata.len())
+    }
+
+    let mut buffer = String::new();
+    std::fs::File::open(path).unwrap()
+        .read_to_string(&mut buffer).unwrap();
+
+    let expected = String::from("\
+    command,mean,stddev,median,user,system,min,max\n\
+    command | 1,1.0,2.0,1.0,3.0,4.0,5.0,6.0\n\
+    command | 2,11.0,12.0,11.0,13.0,14.0,15.0,16.0\n");
+
+    assert_eq!(expected, buffer);
 }

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -4,7 +4,7 @@ use super::Exporter;
 use crate::hyperfine::types::BenchmarkResult;
 use crate::hyperfine::units::Unit;
 
-use std::io::{Error, ErrorKind, Result, Read};
+use std::io::{Error, ErrorKind, Result};
 
 use csv::WriterBuilder;
 use csv::Writer;
@@ -50,6 +50,8 @@ fn strip_times_and_write(writer: &mut Writer<File>, result: &BenchmarkResult) ->
 /// Integration test
 #[test]
 fn test_lines_are_appended() { 
+    use std::io::Read;
+
     let path = &String::from("incremental.csv");
     let mut exporter = CsvExporter::new(path);
     

--- a/src/hyperfine/export/json.rs
+++ b/src/hyperfine/export/json.rs
@@ -24,4 +24,7 @@ impl Exporter for JsonExporter {
 
         output.map_err(|e| Error::new(ErrorKind::Other, e))
     }
+    fn write_to_file_incremental(&mut self, _: &BenchmarkResult, _: Option<Unit>) -> Result<()> { 
+        todo!() 
+    }
 }

--- a/src/hyperfine/export/json.rs
+++ b/src/hyperfine/export/json.rs
@@ -25,6 +25,6 @@ impl Exporter for JsonExporter {
         output.map_err(|e| Error::new(ErrorKind::Other, e))
     }
     fn write_to_file_incremental(&mut self, _: &BenchmarkResult, _: Option<Unit>) -> Result<()> { 
-        todo!() 
+        Ok(())
     }
 }

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -34,7 +34,7 @@ impl Exporter for MarkdownExporter {
         Ok(destination)
     }
     fn write_to_file_incremental(&mut self, _: &BenchmarkResult, _: Option<Unit>) -> Result<()> { 
-        todo!() 
+        Ok(())
     }
 }
 

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -33,6 +33,9 @@ impl Exporter for MarkdownExporter {
 
         Ok(destination)
     }
+    fn write_to_file_incremental(&mut self, _: &BenchmarkResult, _: Option<Unit>) -> Result<()> { 
+        todo!() 
+    }
 }
 
 fn table_header(unit_short_name: String) -> String {

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -179,8 +179,6 @@ pub struct HyperfineOptions {
 
     /// Which time unit to use for CLI & Markdown output
     pub time_unit: Option<Unit>,
-
-    pub incremental_export: bool
 }
 
 impl Default for HyperfineOptions {
@@ -195,8 +193,7 @@ impl Default for HyperfineOptions {
             output_style: OutputStyleOption::Full,
             shell: DEFAULT_SHELL.to_string(),
             show_output: false,
-            time_unit: None,
-            incremental_export: false
+            time_unit: None
         }
     }
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -179,6 +179,8 @@ pub struct HyperfineOptions {
 
     /// Which time unit to use for CLI & Markdown output
     pub time_unit: Option<Unit>,
+
+    pub incremental_export: bool
 }
 
 impl Default for HyperfineOptions {
@@ -194,6 +196,7 @@ impl Default for HyperfineOptions {
             shell: DEFAULT_SHELL.to_string(),
             show_output: false,
             time_unit: None,
+            incremental_export: false
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,7 @@ fn run(commands: &[Command<'_>], options: &HyperfineOptions, export_manager: &mu
     for (num, cmd) in commands.iter().enumerate() {
         let results = run_benchmark(num, cmd, shell_spawning_time, options)?;
         
-        if options.incremental_export { 
-            export_manager.write_incremental_results(&results, options.time_unit)?;
-        }
+        export_manager.write_incremental_results(&results, options.time_unit)?;
         
         timing_results.push(results);
     }
@@ -139,7 +137,6 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
     options.cleanup_command = matches.value_of("cleanup").map(String::from);
 
     options.show_output = matches.is_present("show-output");
-    options.incremental_export = matches.is_present("incremental-export");
 
     options.output_style = match matches.value_of("style") {
         Some("full") => OutputStyleOption::Full,


### PR DESCRIPTION
Adds the ability to write CSV results incrementally to a file, rather than waiting till all of the tests have finished to write export the results using the `incremental-export` option.

Makes the `CsvExporter::new` method require the path so it can maintain an open writer to write the output to a file. As the exporter contains a writer, and calls to `write_incremental_results` mutate the internal writer, this and the ExportManager need to be borrowed mutably by the `run()` function. 