### PR TITLE
Support matrices of independent parameter lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 # unreleased
 
 ## Features
+
+- The `-L`/`--parameter-list` option can now be specified multiple times to evaluate all possible combinations of the listed parameters:
+
+  ``` bash
+  hyperfine -L number 1,2 -L letter a,b,c \
+      "echo {number}{letter}" \
+      "printf '%s\n' {number}{letter}"
+  # runs 12 benchmarks: 2 commands (echo and printf) times 6 combinations of
+  # the "letter" and "number" parameters
+  ```
+
+  See: #253, #318 (@wchargin)
+
 ## Changes
+
+- When parameters are used with `--parameter-list` or `--parameter-scan`, the JSON export format now contains a dictionary `parameters` instead of a single key `parameter`.
+
 ## Bugfixes
 ## Other
 ## Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ## Changes
 
-- When parameters are used with `--parameter-list` or `--parameter-scan`, the JSON export format now contains a dictionary `parameters` instead of a single key `parameter`.
+- When parameters are used with `--parameter-list` or `--parameter-scan`, the JSON export format now contains a dictionary `parameters` instead of a single key `parameter`. See #253, #318.
+- The `plot_parametrized.py` script now infers the parameter name, and its `--parameter-name` argument has been deprecated. See #253, #318.
 
 ## Bugfixes
 ## Other

--- a/scripts/plot_parametrized.py
+++ b/scripts/plot_parametrized.py
@@ -6,6 +6,7 @@ errorbar plot."""
 import argparse
 import json
 import matplotlib.pyplot as plt
+import sys
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("file", help="JSON file with benchmark results", nargs="+")
@@ -13,7 +14,7 @@ parser.add_argument(
     "--parameter-name",
     metavar="name",
     type=str,
-    help="Name of the parameter / x-axis label",
+    help="Deprecated; parameter names are now inferred from benchmark files",
 )
 parser.add_argument(
     "--log-x", help="Use a logarithmic x (parameter) axis", action="store_true"
@@ -26,18 +27,66 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+if args.parameter_name is not None:
+    sys.stderr.write(
+        "warning: --parameter-name is deprecated; names are inferred from "
+        "benchmark results\n"
+    )
+
+
+def die(msg):
+    sys.stderr.write("fatal: %s\n" % (msg,))
+    sys.exit(1)
+
+
+def extract_parameters(results):
+    """Return `(parameter_name: str, parameter_values: List[float])`."""
+    if not results:
+        die("no benchmark data to plot")
+    (names, values) = zip(*(unique_parameter(b) for b in results))
+    names = frozenset(names)
+    if len(names) != 1:
+        die(
+            "benchmarks must all have the same parameter name, but found: %s"
+            % sorted(names)
+        )
+    return (next(iter(names)), values)
+
+
+def unique_parameter(benchmark):
+    """Return the unique parameter `(name: str, value: float)`, or dies."""
+    params_dict = benchmark.get("parameters", {})
+    if not params_dict:
+        die("benchmarks must have exactly one parameter, but found none")
+    if len(params_dict) > 1:
+        die(
+            "benchmarks must have exactly one parameter, but found multiple: %s"
+            % sorted(params_dict)
+        )
+    return next(iter(params_dict.items()))
+
+
+parameter_name = None
 
 for filename in args.file:
     with open(filename) as f:
         results = json.load(f)["results"]
 
-    parameter_values = [float(b["parameter"]) for b in results]
+    (this_parameter_name, parameter_values) = extract_parameters(results)
+    if parameter_name is not None and this_parameter_name != parameter_name:
+        die(
+            "files must all have the same parameter name, but found %r vs. %r"
+            % (parameter_name, this_parameter_name)
+        )
+    parameter_name = this_parameter_name
+
+    parameter_values = [float(pv) for pv in parameter_values]
     times_mean = [b["mean"] for b in results]
     times_stddev = [b["stddev"] for b in results]
 
     plt.errorbar(x=parameter_values, y=times_mean, yerr=times_stddev, capsize=2)
 
-plt.xlabel(args.parameter_name)
+plt.xlabel(parameter_name)
 plt.ylabel("Time [s]")
 
 if args.log_time:

--- a/scripts/plot_parametrized.py
+++ b/scripts/plot_parametrized.py
@@ -50,11 +50,11 @@ def extract_parameters(results):
             "benchmarks must all have the same parameter name, but found: %s"
             % sorted(names)
         )
-    return (next(iter(names)), values)
+    return (next(iter(names)), list(values))
 
 
 def unique_parameter(benchmark):
-    """Return the unique parameter `(name: str, value: float)`, or dies."""
+    """Return the unique parameter `(name: str, value: float)`, or die."""
     params_dict = benchmark.get("parameters", {})
     if not params_dict:
         die("benchmarks must have exactly one parameter, but found none")
@@ -63,7 +63,8 @@ def unique_parameter(benchmark):
             "benchmarks must have exactly one parameter, but found multiple: %s"
             % sorted(params_dict)
         )
-    return next(iter(params_dict.items()))
+    [(name, value)] = params_dict.items()
+    return (name, float(value))
 
 
 parameter_name = None
@@ -80,7 +81,6 @@ for filename in args.file:
         )
     parameter_name = this_parameter_name
 
-    parameter_values = [float(pv) for pv in parameter_values]
     times_mean = [b["mean"] for b in results]
     times_stddev = [b["stddev"] for b in results]
 

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -3,9 +3,10 @@ use atty::Stream;
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches};
 use std::ffi::OsString;
 
-pub fn get_arg_matches<T>(args: T) -> ArgMatches<'static>
+pub fn get_arg_matches<I, T>(args: I) -> ArgMatches<'static>
 where
-    T: Iterator<Item = OsString>,
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
 {
     let app = build_app();
     app.get_matches_from(args)
@@ -134,6 +135,7 @@ fn build_app() -> App<'static, 'static> {
                 .long("parameter-list")
                 .short("L")
                 .takes_value(true)
+                .multiple(true)
                 .allow_hyphen_values(true)
                 .value_names(&["VAR", "VALUES"])
                 .conflicts_with_all(&["parameter-scan", "parameter-step-size"])

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -223,12 +223,7 @@ pub fn run_benchmark(
         } else {
             &values[num]
         };
-        match cmd.get_parameter() {
-            Some((param, value)) => {
-                Command::new_parametrized(preparation_command, param, value.clone())
-            }
-            None => Command::new(preparation_command),
-        }
+        Command::new_parametrized(preparation_command, cmd.get_parameters().clone())
     });
 
     // Warmup phase
@@ -414,16 +409,9 @@ pub fn run_benchmark(
     }
 
     // Run cleanup command
-    let cleanup_cmd =
-        options
-            .cleanup_command
-            .as_ref()
-            .map(|cleanup_command| match cmd.get_parameter() {
-                Some((param, value)) => {
-                    Command::new_parametrized(cleanup_command, param, value.clone())
-                }
-                None => Command::new(cleanup_command),
-            });
+    let cleanup_cmd = options.cleanup_command.as_ref().map(|cleanup_command| {
+        Command::new_parametrized(cleanup_command, cmd.get_parameters().clone())
+    });
     run_cleanup_command(&options.shell, &cleanup_cmd, options.show_output)?;
 
     Ok(BenchmarkResult::new(
@@ -436,6 +424,9 @@ pub fn run_benchmark(
         t_min,
         t_max,
         times_real,
-        cmd.get_parameter().as_ref().map(|p| p.1.to_string()),
+        cmd.get_parameters()
+            .iter()
+            .map(|(name, value)| ((*name).to_string(), value.to_string()))
+            .collect(),
     ))
 }

--- a/src/hyperfine/export/asciidoc.rs
+++ b/src/hyperfine/export/asciidoc.rs
@@ -83,6 +83,7 @@ fn test_asciidoc_header() {
 /// Ensure each table row is generated properly
 #[test]
 fn test_asciidoc_table_row() {
+    use std::collections::BTreeMap;
     let result = BenchmarkResult::new(
         String::from("sleep 1"), // command
         0.10491992406666667,     // mean
@@ -98,7 +99,7 @@ fn test_asciidoc_table_row() {
             0.10745223440000001,
             0.10697327940000001,
         ],
-        None, // param
+        BTreeMap::new(), // param
     );
 
     let expms = format!(
@@ -134,6 +135,7 @@ fn test_asciidoc_table_row() {
 /// Ensure commands get properly escaped
 #[test]
 fn test_asciidoc_table_row_command_escape() {
+    use std::collections::BTreeMap;
     let result = BenchmarkResult::new(
         String::from("sleep 1|"), // command
         0.10491992406666667,      // mean
@@ -149,7 +151,7 @@ fn test_asciidoc_table_row_command_escape() {
             0.10745223440000001,
             0.10697327940000001,
         ],
-        None, // param
+        BTreeMap::new(), // param
     );
     let exps = format!(
         "| `sleep 1\\|`\n\
@@ -169,11 +171,12 @@ fn test_asciidoc_table_row_command_escape() {
 /// Integration test
 #[test]
 fn test_asciidoc() {
+    use std::collections::BTreeMap;
     let exporter = AsciidocExporter::default();
     // NOTE: results are fabricated, unlike above
     let results = vec![
         BenchmarkResult::new(
-            String::from("command | 1"),
+            String::from("FOO=1 BAR=2 command | 1"),
             1.0,
             2.0,
             1.0,
@@ -182,10 +185,15 @@ fn test_asciidoc() {
             5.0,
             6.0,
             vec![7.0, 8.0, 9.0],
-            None,
+            {
+                let mut params = BTreeMap::new();
+                params.insert("foo".into(), "1".into());
+                params.insert("bar".into(), "2".into());
+                params
+            },
         ),
         BenchmarkResult::new(
-            String::from("command | 2"),
+            String::from("FOO=1 BAR=7 command | 2"),
             11.0,
             12.0,
             11.0,
@@ -194,7 +202,12 @@ fn test_asciidoc() {
             15.0,
             16.0,
             vec![17.0, 18.0, 19.0],
-            None,
+            {
+                let mut params = BTreeMap::new();
+                params.insert("foo".into(), "1".into());
+                params.insert("bar".into(), "7".into());
+                params
+            },
         ),
     ];
     // NOTE: only testing with s, s/ms is tested elsewhere
@@ -203,11 +216,11 @@ fn test_asciidoc() {
          |===\n\
          | Command | Mean [s] | Min…Max [s]\n\
          \n\
-         | `command \\| 1`\n\
+         | `FOO=1 BAR=2 command \\| 1`\n\
          | 1.000 ± 2.000\n\
          | 5.000…6.000\n\
          \n\
-         | `command \\| 2`\n\
+         | `FOO=1 BAR=7 command \\| 2`\n\
          | 11.000 ± 12.000\n\
          | 15.000…16.000\n\
          |===\n\

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -3,6 +3,7 @@ use super::Exporter;
 use crate::hyperfine::types::BenchmarkResult;
 use crate::hyperfine::units::Unit;
 
+use std::borrow::Cow;
 use std::io::{Error, ErrorKind, Result};
 
 use csv::WriterBuilder;
@@ -13,16 +14,93 @@ pub struct CsvExporter {}
 impl Exporter for CsvExporter {
     fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
-        for res in results {
-            // The list of times cannot be exported to the CSV file - remove it:
-            let mut result = res.clone();
-            result.times = None;
 
-            writer.serialize(result)?;
+        {
+            let mut headers: Vec<String> = [
+                // The list of times cannot be exported to the CSV file - omit it.
+                "command", "mean", "stddev", "median", "user", "system", "min", "max",
+            ]
+            .iter()
+            .map(|x| (*x).to_string())
+            .collect();
+            if let Some(res) = results.first() {
+                for param_name in res.parameters.keys() {
+                    headers.push(format!("parameter_{}", param_name));
+                }
+            }
+            writer.write_record(headers)?;
+        }
+
+        for res in results {
+            let mut fields = Vec::new();
+            fields.push(Cow::Borrowed(res.command.as_bytes()));
+            for f in &[
+                res.mean, res.stddev, res.median, res.user, res.system, res.min, res.max,
+            ] {
+                fields.push(Cow::Owned(f.to_string().into_bytes()))
+            }
+            for v in res.parameters.values() {
+                fields.push(Cow::Borrowed(v.as_bytes()))
+            }
+            writer.write_record(fields)?;
         }
 
         writer
             .into_inner()
             .map_err(|e| Error::new(ErrorKind::Other, e))
     }
+}
+
+#[test]
+fn test_csv() {
+    use std::collections::BTreeMap;
+    let exporter = CsvExporter::default();
+
+    // NOTE: results are fabricated
+    let results = vec![
+        BenchmarkResult::new(
+            String::from("FOO=one BAR=two command | 1"),
+            1.0,
+            2.0,
+            1.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            vec![7.0, 8.0, 9.0],
+            {
+                let mut params = BTreeMap::new();
+                params.insert("foo".into(), "one".into());
+                params.insert("bar".into(), "two".into());
+                params
+            },
+        ),
+        BenchmarkResult::new(
+            String::from("FOO=one BAR=seven command | 2"),
+            11.0,
+            12.0,
+            11.0,
+            13.0,
+            14.0,
+            15.0,
+            16.5,
+            vec![17.0, 18.0, 19.0],
+            {
+                let mut params = BTreeMap::new();
+                params.insert("foo".into(), "one".into());
+                params.insert("bar".into(), "seven".into());
+                params
+            },
+        ),
+    ];
+    let exps: String = String::from(
+        "command,mean,stddev,median,user,system,min,max,parameter_bar,parameter_foo\n\
+        FOO=one BAR=two command | 1,1,2,1,3,4,5,6,two,one\n\
+        FOO=one BAR=seven command | 2,11,12,11,13,14,15,16.5,seven,one\n\
+        ",
+    );
+    let gens =
+        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+
+    assert_eq!(exps, gens);
 }

--- a/src/hyperfine/export/csv.rs
+++ b/src/hyperfine/export/csv.rs
@@ -16,16 +16,16 @@ impl Exporter for CsvExporter {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
 
         {
-            let mut headers: Vec<String> = [
+            let mut headers: Vec<Cow<[u8]>> = [
                 // The list of times cannot be exported to the CSV file - omit it.
                 "command", "mean", "stddev", "median", "user", "system", "min", "max",
             ]
             .iter()
-            .map(|x| (*x).to_string())
+            .map(|x| Cow::Borrowed(x.as_bytes()))
             .collect();
             if let Some(res) = results.first() {
                 for param_name in res.parameters.keys() {
-                    headers.push(format!("parameter_{}", param_name));
+                    headers.push(Cow::Owned(format!("parameter_{}", param_name).into_bytes()));
                 }
             }
             writer.write_record(headers)?;

--- a/src/hyperfine/export/markdown.rs
+++ b/src/hyperfine/export/markdown.rs
@@ -82,6 +82,7 @@ fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResultWithRelativeSpeed, u
 /// the units for all entries when the time unit is not given.
 #[test]
 fn test_markdown_format_ms() {
+    use std::collections::BTreeMap;
     let exporter = MarkdownExporter::default();
 
     let mut timing_results = vec![];
@@ -96,7 +97,7 @@ fn test_markdown_format_ms() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -109,7 +110,7 @@ fn test_markdown_format_ms() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     let formatted = String::from_utf8(exporter.serialize(&timing_results, None).unwrap()).unwrap();
@@ -129,6 +130,7 @@ fn test_markdown_format_ms() {
 /// the units for all entries when the time unit is not given.
 #[test]
 fn test_markdown_format_s() {
+    use std::collections::BTreeMap;
     let exporter = MarkdownExporter::default();
 
     let mut timing_results = vec![];
@@ -143,7 +145,7 @@ fn test_markdown_format_s() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -156,7 +158,7 @@ fn test_markdown_format_s() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     let formatted = String::from_utf8(exporter.serialize(&timing_results, None).unwrap()).unwrap();
@@ -175,6 +177,7 @@ fn test_markdown_format_s() {
 /// The given time unit (s) is used to set the units for all entries.
 #[test]
 fn test_markdown_format_time_unit_s() {
+    use std::collections::BTreeMap;
     let exporter = MarkdownExporter::default();
 
     let mut timing_results = vec![];
@@ -189,7 +192,7 @@ fn test_markdown_format_time_unit_s() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -202,7 +205,7 @@ fn test_markdown_format_time_unit_s() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     let formatted = String::from_utf8(
@@ -227,6 +230,7 @@ fn test_markdown_format_time_unit_s() {
 /// the units for all entries.
 #[test]
 fn test_markdown_format_time_unit_ms() {
+    use std::collections::BTreeMap;
     let exporter = MarkdownExporter::default();
 
     let mut timing_results = vec![];
@@ -241,7 +245,7 @@ fn test_markdown_format_time_unit_ms() {
         2.0020,              // min
         2.0080,              // max
         vec![2.0, 2.0, 2.0], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     timing_results.push(BenchmarkResult::new(
@@ -254,7 +258,7 @@ fn test_markdown_format_time_unit_ms() {
         0.1023,              // min
         0.1080,              // max
         vec![0.1, 0.1, 0.1], // times
-        None,                // parameter
+        BTreeMap::new(),     // parameter
     ));
 
     let formatted = String::from_utf8(

--- a/src/hyperfine/internal.rs
+++ b/src/hyperfine/internal.rs
@@ -128,6 +128,7 @@ fn test_max() {
 #[test]
 fn test_compute_relative_speed() {
     use approx::assert_relative_eq;
+    use std::collections::BTreeMap;
 
     let create_result = |name: &str, mean| BenchmarkResult {
         command: name.into(),
@@ -139,7 +140,7 @@ fn test_compute_relative_speed() {
         min: mean,
         max: mean,
         times: None,
-        parameter: None,
+        parameters: BTreeMap::new(),
     };
 
     let results = vec![

--- a/src/hyperfine/parameter_range.rs
+++ b/src/hyperfine/parameter_range.rs
@@ -94,8 +94,7 @@ fn build_parameterized_commands<'a, T: Numeric>(
         for cmd in &command_strings {
             commands.push(Command::new_parametrized(
                 cmd,
-                param_name,
-                ParameterValue::Numeric(value.into()),
+                vec![(param_name, ParameterValue::Numeric(value.into()))],
             ));
         }
     }


### PR DESCRIPTION
This patch permits the `-L`/`--parameter-list` argument to appear
multiple times. Each additional parameter increases the dimensionality
of the parameter matrix. One benchmark will be run for each combination
of parameters (i.e., the benchmark space is the Cartesian product of the
parameter spaces).

For now, `--parameter-list` and `--parameter-scan` are still mutually
exclusive. If desired, a follow-up change could similarly permit
multiple occurrences of `--parameter-scan` and also permit use of both
listed and scanned parameters together. (After all, `--parameter-scan`
can be thought of as syntactic sugar for a parameter list.)

Benchmark results now include a `parameters` dictionary mapping
parameter names to values (as before, omitted when not parameterized).
This means that we can’t use `serde` to serialize to CSV, but a CSV
writer is easy to write by hand, so we do that. This also means that the
JSON output format has changed: write `b.parameters["foo"]` rather than
`b.parameter`.

The `plot_parametrized.py` helper script still requires that there be
exactly one parameter among the input files. We could allow users to
specify one parameter to marginalize over, but then we’d need to
aggregate over the other parameters, which is a bit out of the scope of
this change. The `--parameter-name` argument has been removed, since it
can now be inferred from the output dictionary.

This implementation is a little profligate with memory usage for
`BenchmarkResult`s: each result contains a separate copy of all
parameter names (as `String`s). This could be done away with by
threading lifetimes through the `BenchmarkResult`s, or by ref-counting
the names.

Fixes #253.

Test Plan:
Some unit tests included. As an integration test, try:

```
cargo run --release -- --runs 10 \
    -L foo foo1,foo2 -L bar bar9,bar8 \
    'echo {foo} {bar}' \
    'printf "%s\n" {foo} {bar}' \
    --export-csv /tmp/out
```

with all the export formats.

Screenshot of new `plot_parametrized.py` with two input files, no
`--parameter-name` argument:

```
$ hyperfine -P my_favorite_parameter 1 4 'echo {my_favorite_parameter}' -w 3 --export-json /tmp/echo
$ hyperfine -P my_favorite_parameter 1 4 'printf {my_favorite_parameter}' -w 3 --export-json /tmp/printf
$ python ./scripts/plot_parametrized.py /tmp/echo /tmp/printf
```

![Screenshot showing an error bar chart with two series, with an x-axis
label of “my_favorite_parameter”][plot-ss]

[plot-ss]: https://user-images.githubusercontent.com/4317806/93403577-c5e3fa80-f83c-11ea-8bae-982ac3136040.png

wchargin-branch: param-list-matrix
