### PR TITLE
scripts: modify shebang to use "/usr/bin/env python"

### DIFF
--- a/scripts/advanced_statistics.py
+++ b/scripts/advanced_statistics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
 import json

--- a/scripts/plot_histogram.py
+++ b/scripts/plot_histogram.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """This program shows `hyperfine` benchmark results as a histogram."""
 

--- a/scripts/plot_parametrized.py
+++ b/scripts/plot_parametrized.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """This program shows parametrized `hyperfine` benchmark results as an
 errorbar plot."""

--- a/scripts/plot_whisker.py
+++ b/scripts/plot_whisker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """This program shows `hyperfine` benchmark results as a box and whisker plot.
 

--- a/scripts/welch_ttest.py
+++ b/scripts/welch_ttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """This script performs Welch's t-test on a JSON export file with two
 benchmark results to test whether or not the two distributions are


### PR DESCRIPTION
Before this patch, executing directly one of these scripts, for example `./plot_hystogram.py` in a unix-like environment meant that the default system-level python would be used, regardless of an eventual activated virtualenv.

This was due to the "#!/usr/bin/python" shebang.

Changing it to "/usr/bin/env python" is a fairly standard practice, keeps intact the compatiblity with the system level python, and allows a user to run in a virtualenv if he wants.
