### PR TITLE
add CLI option to identify a command with a custom name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
   See: #253, #318 (@wchargin)
 
+- Add CLI option to identify a command with a custom name, see #326 (@scampi)
+
 ## Changes
 
 - When parameters are used with `--parameter-list` or `--parameter-scan`, the JSON export format now contains a dictionary `parameters` instead of a single key `parameter`. See #253, #318.

--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -164,7 +164,7 @@ Print the stdout and stderr of the benchmark instead of suppressing it. This
 will increase the time it takes for benchmarks to run, so it should only be
 used for debugging purposes or when trying to benchmark output speed.
 .HP
-\fB\-\-name\fR \fIname\fP
+\fB\-n\fR, \fB\-\-command\-name\fR \fIname\fP
 .IP
 Identify a command with the given \fIname\fP. Commands and names are paired in
 the same order: the first command executed gets the first name passed as

--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -164,6 +164,12 @@ Print the stdout and stderr of the benchmark instead of suppressing it. This
 will increase the time it takes for benchmarks to run, so it should only be
 used for debugging purposes or when trying to benchmark output speed.
 .HP
+\fB\-\-name\fR \fIname\fP
+.IP
+Identify a command with the given \fIname\fP. Commands and names are paired in
+the same order: the first command executed gets the first name passed as
+option.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Print help message.

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -228,7 +228,7 @@ fn build_app() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name("command-name")
-                .long("name")
+                .long("command-name")
                 .short("n")
                 .takes_value(true)
                 .multiple(true)

--- a/src/hyperfine/app.rs
+++ b/src/hyperfine/app.rs
@@ -226,6 +226,16 @@ fn build_app() -> App<'static, 'static> {
                      when trying to benchmark output speed.",
                 ),
         )
+        .arg(
+            Arg::with_name("command-name")
+                .long("name")
+                .short("n")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1)
+                .value_name("NAME")
+                .help("Give a meaningful name to a command"),
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.")
 }

--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -202,12 +202,20 @@ pub fn run_benchmark(
     shell_spawning_time: TimingResult,
     options: &HyperfineOptions,
 ) -> io::Result<BenchmarkResult> {
+    let shell_cmd = cmd.get_shell_command();
+    let command_name = if let Some(names) = &options.names {
+        names.get(num).unwrap_or(&shell_cmd)
+    } else {
+        &shell_cmd
+    };
+    let command_name = command_name.to_string();
+
     if options.output_style != OutputStyleOption::Disabled {
         println!(
             "{}{}: {}",
             "Benchmark #".bold(),
             (num + 1).to_string().bold(),
-            cmd
+            &command_name
         );
     }
 
@@ -415,7 +423,7 @@ pub fn run_benchmark(
     run_cleanup_command(&options.shell, &cleanup_cmd, options.show_output)?;
 
     Ok(BenchmarkResult::new(
-        cmd.get_shell_command(),
+        command_name,
         t_mean,
         t_stddev,
         t_median,

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -49,6 +49,7 @@ impl Error for ParameterScanError {}
 pub enum OptionsError {
     RunsBelowTwo,
     EmptyRunsRange,
+    TooManyCommandNames(usize),
 }
 
 impl fmt::Display for OptionsError {
@@ -56,6 +57,9 @@ impl fmt::Display for OptionsError {
         match *self {
             OptionsError::EmptyRunsRange => write!(f, "Empty runs range"),
             OptionsError::RunsBelowTwo => write!(f, "Number of runs below two"),
+            OptionsError::TooManyCommandNames(n) => {
+                write!(f, "Too many --command-name options: expected {} at most", n)
+            }
         }
     }
 }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -210,11 +210,14 @@ pub struct HyperfineOptions {
 
     /// Which time unit to use for CLI & Markdown output
     pub time_unit: Option<Unit>,
+
+    pub names: Option<Vec<String>>,
 }
 
 impl Default for HyperfineOptions {
     fn default() -> HyperfineOptions {
         HyperfineOptions {
+            names: None,
             warmup_count: 0,
             runs: Runs::default(),
             min_time_sec: 3.0,

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -211,6 +211,9 @@ pub struct HyperfineOptions {
     /// Which time unit to use for CLI & Markdown output
     pub time_unit: Option<Unit>,
 
+    /// A list of custom command names that, if defined,
+    /// will be used instead of the command itself in
+    /// benchmark outputs.
     pub names: Option<Vec<String>>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,12 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
     options.names = matches
         .values_of("command-name")
         .map(|values| values.map(String::from).collect::<Vec<String>>());
+    if let Some(ref names) = options.names {
+        let command_strings = matches.values_of("command").unwrap();
+        if names.len() > command_strings.len() {
+            return Err(OptionsError::TooManyCommandNames(command_strings.len()));
+        }
+    }
 
     options.preparation_command = matches
         .values_of("prepare")

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,10 @@ fn build_hyperfine_options(matches: &ArgMatches<'_>) -> Result<HyperfineOptions,
         (None, None) => {}
     };
 
+    options.names = matches
+        .values_of("command-name")
+        .map(|values| values.map(String::from).collect::<Vec<String>>());
+
     options.preparation_command = matches
         .values_of("prepare")
         .map(|values| values.map(String::from).collect::<Vec<String>>());


### PR DESCRIPTION
CLI option `--name` can be used to define the name to identify a
command. If not passed, then the command itself is used. Commands
and names are paired in the same order: The first command executed gets
the first name passed as option.

Close #326