### PR TITLE
Show error if numeric arguments can not be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix a bug in the outlier detection which would only detect "slow outliers" but not the fast ones (runs that are much faster than the rest of the benchmarking runs), see #329
 - Better error messages for very fast commands that would lead to inf/nan results in the relative
   speed comparison, see #319
+- Show error message if `--warmup` or `--*runs` arguments can not be parsed, see #337
 - Keep output colorized when the output is not interactive and `--style=full` or `--style=color` is used.
 
 ## Other

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -2,6 +2,7 @@ use rust_decimal::Error as DecimalError;
 use std::error::Error;
 use std::fmt;
 use std::num;
+use std::num::ParseIntError;
 
 #[derive(Debug)]
 pub enum ParameterScanError {
@@ -46,13 +47,14 @@ impl fmt::Display for ParameterScanError {
 impl Error for ParameterScanError {}
 
 #[derive(Debug)]
-pub enum OptionsError {
+pub enum OptionsError<'a> {
     RunsBelowTwo,
     EmptyRunsRange,
     TooManyCommandNames(usize),
+    NumericParsingError(&'a str, ParseIntError),
 }
 
-impl fmt::Display for OptionsError {
+impl<'a> fmt::Display for OptionsError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             OptionsError::EmptyRunsRange => write!(f, "Empty runs range"),
@@ -60,8 +62,14 @@ impl fmt::Display for OptionsError {
             OptionsError::TooManyCommandNames(n) => {
                 write!(f, "Too many --command-name options: expected {} at most", n)
             }
+            OptionsError::NumericParsingError(cmd, ref err) => write!(
+                f,
+                "Could not read numeric argument to '--{cmd}': {err}",
+                cmd = cmd,
+                err = err
+            ),
         }
     }
 }
 
-impl Error for OptionsError {}
+impl<'a> Error for OptionsError<'a> {}


### PR DESCRIPTION
Shows an error message if the argument to options like `--warmup <N>`
can not be parsed:

    > hyperfine --warmup xxx "sleep 1"
    Error: Could not read numeric argument to '--warmup': invalid digit found in string

closes #337