### PR TITLE
Export intermediate results after each benchmark command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Changes
 
+- When `--export-*` options are used, result files are written after each individual 
+  benchmark command instead of writing after all benchmarks have finished. See #306 (@s1ck).
+
 ## Bugfixes
 
 ## Other

--- a/src/hyperfine/export/mod.rs
+++ b/src/hyperfine/export/mod.rs
@@ -69,7 +69,7 @@ impl ExportManager {
     }
 
     /// Write the given results to all Exporters contained within this manager
-    pub fn write_results(&self, results: Vec<BenchmarkResult>, unit: Option<Unit>) -> Result<()> {
+    pub fn write_results(&self, results: &[BenchmarkResult], unit: Option<Unit>) -> Result<()> {
         for e in &self.exporters {
             let file_content = e.exporter.serialize(&results, unit)?;
             write_to_file(&e.filename, &file_content)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,20 +49,20 @@ fn run(
     // Run the benchmarks
     for (num, cmd) in commands.iter().enumerate() {
         timing_results.push(run_benchmark(num, cmd, shell_spawning_time, options)?);
+
+        // Export (intermediate) results
+        let ans = export_manager.write_results(&timing_results, options.time_unit);
+        if let Err(e) = ans {
+            error(&format!(
+                "The following error occurred while exporting: {}",
+                e
+            ));
+        }
     }
 
     // Print relative speed comparison
     if options.output_style != OutputStyleOption::Disabled {
         write_benchmark_comparison(&timing_results);
-    }
-
-    // Export results
-    let ans = export_manager.write_results(timing_results, options.time_unit);
-    if let Err(e) = ans {
-        error(&format!(
-            "The following error occurred while exporting: {}",
-            e
-        ));
     }
 
     Ok(())


### PR DESCRIPTION
fixes #306 

I took a very simple approach, by just exporting all benchmark results after each benchmark command has run. It re-creates the file, but still allows using e.g. `tail -f`.

Please let me know if this fits the requirements, happy to work on a more sophisticated implementation, e.g. opening the file and trying to append individual results, however, this becomes a bit more complicated for json I assume.