### PR TITLE
Adds tip for benchmarking aliases and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ option:
 hyperfine --min-runs 5 'sleep 0.2' 'sleep 3.2'
 ```
 
+### Tip: aliases and functions
+
+Aliases and shell functions can't be benchmarked directly, but you may try to put them in a separate
+file and benchmark _that_:
+
+```bash
+echo 'my_function() { sleep 1 }' > /tmp/my_function.sh
+echo 'alias my_alias="sleep 1"' > /tmp/my_alias.sh
+hyperfine 'source /tmp/my_function.sh; eval my_function'
+hyperfine 'source /tmp/my_alias.sh; eval my_alias'
+```
+
+If you're using bash, you may also want to `export` functions (can't do that with aliases, though):
+
+```
+$ my_function() { sleep 1; }
+$ export -f my_function
+$ hyperfine my_function
+```
+
 ### Warmup runs and preparation commands
 
 If the program execution time is limited by disk I/O, the benchmarking results can be heavily

--- a/README.md
+++ b/README.md
@@ -40,26 +40,6 @@ option:
 hyperfine --min-runs 5 'sleep 0.2' 'sleep 3.2'
 ```
 
-### Tip: aliases and functions
-
-Aliases and shell functions can't be benchmarked directly, but you may try to put them in a separate
-file and benchmark _that_:
-
-```bash
-echo 'my_function() { sleep 1 }' > /tmp/my_function.sh
-echo 'alias my_alias="sleep 1"' > /tmp/my_alias.sh
-hyperfine 'source /tmp/my_function.sh; eval my_function'
-hyperfine 'source /tmp/my_alias.sh; eval my_alias'
-```
-
-If you're using bash, you may also want to `export` functions (can't do that with aliases, though):
-
-```
-$ my_function() { sleep 1; }
-$ export -f my_function
-$ hyperfine my_function
-```
-
 ### Warmup runs and preparation commands
 
 If the program execution time is limited by disk I/O, the benchmarking results can be heavily
@@ -96,6 +76,26 @@ to control the step size:
 hyperfine --parameter-scan delay 0.3 0.7 -D 0.2 'sleep {delay}'
 ```
 This runs `sleep 0.3`, `sleep 0.5` and `sleep 0.7`.
+
+### Shell functions and aliases
+
+If you are using bash, you can export shell functions to directly benchmark them with hyperfine:
+
+```
+$ my_function() { sleep 1; }
+$ export -f my_function
+$ hyperfine my_function
+```
+
+If you are using a different shell, or if you want to benchmark shell aliases, you may try to put
+them in a separate file:
+
+```bash
+echo 'my_function() { sleep 1 }' > /tmp/my_function.sh
+echo 'alias my_alias="sleep 1"' > /tmp/my_alias.sh
+hyperfine 'source /tmp/my_function.sh; eval my_function'
+hyperfine 'source /tmp/my_alias.sh; eval my_alias'
+```
 
 ### Export results
 


### PR DESCRIPTION
This adds a section to the README with a tip for benchmarking aliases and shell functions. The location for the section is totally up for debate. Maybe it is too proeminent for an edge case?

Solution unashamedly stolen from sharkdp's solution for #270.

Fixes #270