### PR TITLE
Add parameters to plotting scripts

### DIFF
--- a/scripts/plot_histogram.py
+++ b/scripts/plot_histogram.py
@@ -17,7 +17,10 @@ parser.add_argument("--bins", help="Number of bins (default: auto)")
 parser.add_argument(
     "--type", help="Type of histogram (*bar*, barstacked, step, stepfilled)"
 )
-parser.add_argument("--imgname", help="Save image to the given filename.")
+parser.add_argument(
+    "-o", "--output", help="Save image to the given filename."
+)
+
 args = parser.parse_args()
 
 with open(args.file) as f:
@@ -44,7 +47,7 @@ plt.xlabel("Time [s]")
 if args.title:
     plt.title(args.title)
 
-if args.imgname:
-    plt.savefig(args.imgname)
+if args.output:
+    plt.savefig(args.output)
 else:
     plt.show()

--- a/scripts/plot_histogram.py
+++ b/scripts/plot_histogram.py
@@ -10,16 +10,23 @@ import matplotlib.pyplot as plt
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("file", help="JSON file with benchmark results")
 parser.add_argument("--title", help="Plot title")
+parser.add_argument(
+    "--labels", help="Comma-separated list of entries for the plot legend"
+)
 parser.add_argument("--bins", help="Number of bins (default: auto)")
 parser.add_argument(
     "--type", help="Type of histogram (*bar*, barstacked, step, stepfilled)"
 )
+parser.add_argument("--imgname", help="Save image to the given filename.")
 args = parser.parse_args()
 
 with open(args.file) as f:
     results = json.load(f)["results"]
 
-commands = [b["command"] for b in results]
+if args.labels:
+    labels = args.labels.split(",")
+else:
+    labels = [b["command"] for b in results]
 all_times = [b["times"] for b in results]
 
 t_min = np.min(list(map(np.min, all_times)))
@@ -29,7 +36,7 @@ bins = int(args.bins) if args.bins else "auto"
 histtype = args.type if args.type else "bar"
 
 plt.hist(
-    all_times, label=commands, bins=bins, histtype=histtype, range=(t_min, t_max),
+    all_times, label=labels, bins=bins, histtype=histtype, range=(t_min, t_max),
 )
 plt.legend(prop={"family": ["Source Code Pro", "Fira Mono", "Courier New"]})
 
@@ -37,4 +44,7 @@ plt.xlabel("Time [s]")
 if args.title:
     plt.title(args.title)
 
-plt.show()
+if args.imgname:
+    plt.savefig(args.imgname)
+else:
+    plt.show()

--- a/scripts/plot_parametrized.py
+++ b/scripts/plot_parametrized.py
@@ -25,6 +25,7 @@ parser.add_argument(
 parser.add_argument(
     "--titles", help="Comma-separated list of titles for the plot legend"
 )
+parser.add_argument("--imgname", help="Save image to the given filename.")
 
 args = parser.parse_args()
 if args.parameter_name is not None:
@@ -100,4 +101,7 @@ if args.log_x:
 if args.titles:
     plt.legend(args.titles.split(","))
 
-plt.show()
+if args.imgname:
+    plt.savefig(args.imgname)
+else:
+    plt.show()

--- a/scripts/plot_parametrized.py
+++ b/scripts/plot_parametrized.py
@@ -25,7 +25,9 @@ parser.add_argument(
 parser.add_argument(
     "--titles", help="Comma-separated list of titles for the plot legend"
 )
-parser.add_argument("--imgname", help="Save image to the given filename.")
+parser.add_argument(
+    "-o", "--output", help="Save image to the given filename."
+)
 
 args = parser.parse_args()
 if args.parameter_name is not None:
@@ -101,7 +103,7 @@ if args.log_x:
 if args.titles:
     plt.legend(args.titles.split(","))
 
-if args.imgname:
-    plt.savefig(args.imgname)
+if args.output:
+    plt.savefig(args.output)
 else:
     plt.show()

--- a/scripts/plot_whisker.py
+++ b/scripts/plot_whisker.py
@@ -18,6 +18,7 @@ parser.add_argument("--title", help="Plot Title")
 parser.add_argument(
     "--labels", help="Comma-separated list of entries for the plot legend"
 )
+parser.add_argument("--imgname", help="Save image to the given filename.")
 args = parser.parse_args()
 
 with open(args.file) as f:
@@ -41,4 +42,7 @@ if args.title:
 plt.legend(handles=boxplot["boxes"], labels=labels, loc="best", fontsize="medium")
 plt.ylabel("Time [s]")
 plt.ylim(0, None)
-plt.show()
+if args.imgname:
+    plt.savefig(args.imgname)
+else:
+    plt.show()

--- a/scripts/plot_whisker.py
+++ b/scripts/plot_whisker.py
@@ -18,7 +18,10 @@ parser.add_argument("--title", help="Plot Title")
 parser.add_argument(
     "--labels", help="Comma-separated list of entries for the plot legend"
 )
-parser.add_argument("--imgname", help="Save image to the given filename.")
+parser.add_argument(
+    "-o", "--output", help="Save image to the given filename."
+)
+
 args = parser.parse_args()
 
 with open(args.file) as f:
@@ -42,7 +45,7 @@ if args.title:
 plt.legend(handles=boxplot["boxes"], labels=labels, loc="best", fontsize="medium")
 plt.ylabel("Time [s]")
 plt.ylim(0, None)
-if args.imgname:
-    plt.savefig(args.imgname)
+if args.output:
+    plt.savefig(args.output)
 else:
     plt.show()


### PR DESCRIPTION
Add ~`imgname`~ `output` parameter to be able to save a plot to a file instead of showing it.
Use-case: platforms without GUI like docker containers.

Add `labels` parameter to histogram plot.
Use-case: replacing long commands with human friendly labels.