### PR TITLE
Added tab-completion support for Elvish shell

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,4 +28,5 @@ fn main() {
     app.gen_completions("hyperfine", Shell::Fish, &outdir);
     app.gen_completions("hyperfine", Shell::Zsh, &outdir);
     app.gen_completions("hyperfine", Shell::PowerShell, &outdir);
+    app.gen_completions("hyperfine", Shell::Elvish, &outdir);
 }


### PR DESCRIPTION
Clap provides tab-completion support for 5 shells bash, fish, zsh, powershell, elvish.

Signed-off-by: parampreetR <raja.rai6789@gmail.com>