### PR TITLE
benchmark.rs: Don't use # in benchmark name

### DIFF
--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -219,7 +219,7 @@ pub fn run_benchmark(
     if options.output_style != OutputStyleOption::Disabled {
         println!(
             "{}{}: {}",
-            "Benchmark #".bold(),
+            "Benchmark ".bold(),
             (num + 1).to_string().bold(),
             &command_name
         );


### PR DESCRIPTION
Using `Benchmark #1` causes github and gitlab to interrupt hyperfine
results as link to issue #1. Remove the # from the benchmark number to
play better with these systems.

Fixes #381.