### PR TITLE
Make --comand-name take arguments from --parameter-list and --parameter-scan

### DIFF
--- a/src/hyperfine/benchmark.rs
+++ b/src/hyperfine/benchmark.rs
@@ -117,7 +117,7 @@ pub fn mean_shell_spawning_time(
         // Just run the shell without any command
         let res = time_shell_command(
             shell,
-            &Command::new(""),
+            &Command::new(None, ""),
             show_output,
             CmdFailureAction::RaiseError,
             None,
@@ -208,20 +208,13 @@ pub fn run_benchmark(
     shell_spawning_time: TimingResult,
     options: &HyperfineOptions,
 ) -> io::Result<BenchmarkResult> {
-    let shell_cmd = cmd.get_shell_command();
-    let command_name = if let Some(names) = &options.names {
-        names.get(num).unwrap_or(&shell_cmd)
-    } else {
-        &shell_cmd
-    };
-    let command_name = command_name.to_string();
-
+    let command_name = cmd.get_name();
     if options.output_style != OutputStyleOption::Disabled {
         println!(
             "{}{}: {}",
             "Benchmark #".bold(),
             (num + 1).to_string().bold(),
-            &command_name
+            command_name,
         );
     }
 
@@ -237,7 +230,7 @@ pub fn run_benchmark(
         } else {
             &values[num]
         };
-        Command::new_parametrized(preparation_command, cmd.get_parameters().clone())
+        Command::new_parametrized(None, preparation_command, cmd.get_parameters().clone())
     });
 
     // Warmup phase
@@ -424,7 +417,7 @@ pub fn run_benchmark(
 
     // Run cleanup command
     let cleanup_cmd = options.cleanup_command.as_ref().map(|cleanup_command| {
-        Command::new_parametrized(cleanup_command, cmd.get_parameters().clone())
+        Command::new_parametrized(None, cleanup_command, cmd.get_parameters().clone())
     });
     run_cleanup_command(&options.shell, &cleanup_cmd, options.show_output)?;
 

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -12,6 +12,7 @@ pub enum ParameterScanError {
     TooLarge,
     ZeroStep,
     StepRequired,
+    DifferentCommandNameCountWithParameters(usize, usize),
 }
 
 impl From<num::ParseIntError> for ParameterScanError {
@@ -40,6 +41,13 @@ impl fmt::Display for ParameterScanError {
                  floating point numbers. The step size can be specified \
                  with the '--parameter-step-size' parameter"
             ),
+            ParameterScanError::DifferentCommandNameCountWithParameters(real, expected) => {
+                write!(
+                    f,
+                    "Current --command-name count is {}: expected {} as parameters",
+                    real, expected
+                )
+            }
         }
     }
 }
@@ -51,6 +59,7 @@ pub enum OptionsError<'a> {
     RunsBelowTwo,
     EmptyRunsRange,
     TooManyCommandNames(usize),
+    DifferentCommandNameCountWithParameters(usize, usize),
     NumericParsingError(&'a str, ParseIntError),
 }
 
@@ -61,6 +70,13 @@ impl<'a> fmt::Display for OptionsError<'a> {
             OptionsError::RunsBelowTwo => write!(f, "Number of runs below two"),
             OptionsError::TooManyCommandNames(n) => {
                 write!(f, "Too many --command-name options: expected {} at most", n)
+            }
+            OptionsError::DifferentCommandNameCountWithParameters(real, expected) => {
+                write!(
+                    f,
+                    "Current --command-name count is {}: expected {} as parameters",
+                    real, expected
+                )
             }
             OptionsError::NumericParsingError(cmd, ref err) => write!(
                 f,

--- a/src/hyperfine/error.rs
+++ b/src/hyperfine/error.rs
@@ -12,7 +12,7 @@ pub enum ParameterScanError {
     TooLarge,
     ZeroStep,
     StepRequired,
-    DifferentCommandNameCountWithParameters(usize, usize),
+    UnexpectedCommandNameCount(usize, usize),
 }
 
 impl From<num::ParseIntError> for ParameterScanError {
@@ -41,10 +41,10 @@ impl fmt::Display for ParameterScanError {
                  floating point numbers. The step size can be specified \
                  with the '--parameter-step-size' parameter"
             ),
-            ParameterScanError::DifferentCommandNameCountWithParameters(real, expected) => {
+            ParameterScanError::UnexpectedCommandNameCount(real, expected) => {
                 write!(
                     f,
-                    "Current --command-name count is {}: expected {} as parameters",
+                    "'--command-name' has been specified {} times. It has to appear exactly once, or exactly {} times (number of benchmarks)",
                     real, expected
                 )
             }
@@ -59,7 +59,7 @@ pub enum OptionsError<'a> {
     RunsBelowTwo,
     EmptyRunsRange,
     TooManyCommandNames(usize),
-    DifferentCommandNameCountWithParameters(usize, usize),
+    UnexpectedCommandNameCount(usize, usize),
     NumericParsingError(&'a str, ParseIntError),
 }
 
@@ -71,10 +71,10 @@ impl<'a> fmt::Display for OptionsError<'a> {
             OptionsError::TooManyCommandNames(n) => {
                 write!(f, "Too many --command-name options: expected {} at most", n)
             }
-            OptionsError::DifferentCommandNameCountWithParameters(real, expected) => {
+            OptionsError::UnexpectedCommandNameCount(real, expected) => {
                 write!(
                     f,
-                    "Current --command-name count is {}: expected {} as parameters",
+                    "'--command-name' has been specified {} times. It has to appear exactly once, or exactly {} times (number of benchmarks)",
                     real, expected
                 )
             }

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -1,7 +1,9 @@
+use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 /// This module contains common internal types.
 use serde::*;
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 use std::fmt;
 
 use crate::hyperfine::units::{Second, Unit};
@@ -37,6 +39,20 @@ impl Into<NumericType> for i32 {
 impl Into<NumericType> for Decimal {
     fn into(self) -> NumericType {
         NumericType::Decimal(self)
+    }
+}
+
+impl TryFrom<NumericType> for usize {
+    type Error = ();
+
+    fn try_from(numeric: NumericType) -> Result<Self, Self::Error> {
+        match numeric {
+            NumericType::Int(i) => usize::try_from(i).map_err(|_| ()),
+            NumericType::Decimal(d) => match d.to_u64() {
+                Some(u) => usize::try_from(u).map_err(|_| ()),
+                None => Err(()),
+            },
+        }
     }
 }
 

--- a/src/hyperfine/types.rs
+++ b/src/hyperfine/types.rs
@@ -58,6 +58,9 @@ impl<'a> ToString for ParameterValue {
 /// A command that should be benchmarked.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Command<'a> {
+    /// The command name (without parameter substitution)
+    name: Option<&'a str>,
+
     /// The command that should be executed (without parameter substitution)
     expression: &'a str,
 
@@ -66,24 +69,42 @@ pub struct Command<'a> {
 }
 
 impl<'a> Command<'a> {
-    pub fn new(expression: &'a str) -> Command<'a> {
+    pub fn new(name: Option<&'a str>, expression: &'a str) -> Command<'a> {
         Command {
+            name,
             expression,
             parameters: Vec::new(),
         }
     }
 
     pub fn new_parametrized(
+        name: Option<&'a str>,
         expression: &'a str,
         parameters: Vec<(&'a str, ParameterValue)>,
     ) -> Command<'a> {
         Command {
+            name,
             expression,
             parameters,
         }
     }
 
+    pub fn get_name(&self) -> String {
+        self.name.map_or_else(
+            || self.get_shell_command(),
+            |name| self.replace_parameters_in(name),
+        )
+    }
+
     pub fn get_shell_command(&self) -> String {
+        self.replace_parameters_in(self.expression)
+    }
+
+    pub fn get_parameters(&self) -> &Vec<(&'a str, ParameterValue)> {
+        &self.parameters
+    }
+
+    fn replace_parameters_in(&self, original: &str) -> String {
         let mut result = String::new();
         let mut replacements = BTreeMap::<String, String>::new();
         for (param_name, param_value) in &self.parameters {
@@ -92,7 +113,7 @@ impl<'a> Command<'a> {
                 param_value.to_string(),
             );
         }
-        let mut remaining = self.expression;
+        let mut remaining = original;
         // Manually replace consecutive occurrences to avoid double-replacing: e.g.,
         //
         //     hyperfine -L foo 'a,{bar}' -L bar 'baz,quux' 'echo {foo} {bar}'
@@ -111,15 +132,12 @@ impl<'a> Command<'a> {
         }
         result
     }
-
-    pub fn get_parameters(&self) -> &Vec<(&'a str, ParameterValue)> {
-        &self.parameters
-    }
 }
 
 #[test]
 fn test_get_shell_command_nonoverlapping() {
     let cmd = Command::new_parametrized(
+        None,
         "echo {foo} {bar}",
         vec![
             ("foo", ParameterValue::Text("{bar} baz".into())),
@@ -127,6 +145,19 @@ fn test_get_shell_command_nonoverlapping() {
         ],
     );
     assert_eq!(cmd.get_shell_command(), "echo {bar} baz quux");
+}
+
+#[test]
+fn test_get_parameterized_command_name() {
+    let cmd = Command::new_parametrized(
+        Some("name-{bar}-{foo}"),
+        "echo {foo} {bar}",
+        vec![
+            ("foo", ParameterValue::Text("baz".into())),
+            ("bar", ParameterValue::Text("quux".into())),
+        ],
+    );
+    assert_eq!(cmd.get_name(), "name-quux-baz");
 }
 
 impl<'a> fmt::Display for Command<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,17 +255,24 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
             return Vec::new();
         }
 
+        // `--command-name` should appear exactly once or same count with parameters.
+        let command_name_count = command_names.len();
+        if command_name_count > 1 && command_name_count != param_space_size {
+            let err = OptionsError::DifferentCommandNameCountWithParameters(
+                command_name_count,
+                param_space_size,
+            );
+            error(&err.to_string());
+        }
+
         let mut i = 0;
-        let name_count = command_names.len();
         let mut commands = Vec::with_capacity(param_space_size);
         let mut index = vec![0usize; dimensions.len()];
         'outer: loop {
-            // Sets the command name by index (remainder) if exists.
-            let name = if name_count > 0 {
-                Some(command_names[i % name_count])
-            } else {
-                None
-            };
+            let name = command_names
+                .get(i)
+                .or_else(|| command_names.get(0))
+                .map(|s| *s);
             i += 1;
 
             let (command_index, params_indices) = index.split_first().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,13 +255,12 @@ fn build_commands<'a>(matches: &'a ArgMatches<'_>) -> Vec<Command<'a>> {
             return Vec::new();
         }
 
-        // `--command-name` should appear exactly once or same count with parameters.
+        // `--command-name` should appear exactly once or exactly B times,
+        // where B is the total number of benchmarks.
         let command_name_count = command_names.len();
         if command_name_count > 1 && command_name_count != param_space_size {
-            let err = OptionsError::DifferentCommandNameCountWithParameters(
-                command_name_count,
-                param_space_size,
-            );
+            let err =
+                OptionsError::UnexpectedCommandNameCount(command_name_count, param_space_size);
             error(&err.to_string());
         }
 


### PR DESCRIPTION
Closes #351 

@sharkdp I am sorry that I lost the previous forked repository. This is the update for the old PR #354 . The [Commit 2](https://github.com/sharkdp/hyperfine/commit/6d9ea3c82893167e12973727557cd315e06b51c6) fixes to limit `--command-name` count appear exactly once or same count with parameters. Please help review if you have time. Thanks.

User could run the parameterized commands as below.

```
hyperfine 'echo {foo}' --parameter-list foo 1,2 --command-name name-{foo}

hyperfine 'echo {val}' --parameter-scan val 1 3 --parameter-step-size 1 --command-name name-{val}
```