### PR TITLE
Update README.md

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@ This folder contains scripts that can be used in combination with hyperfines `--
 ### Example:
 
 ``` bash
-> hyperfine 'sleep 0.020' 'sleep 0.021' 'sleep 0.022' --export-json sleep.json
+> hyperfine 'sleep 0.020' 'sleep 0.021' 'sleep 0.022' --json sleep.json
 > python plot_benchmark_results.py sleep.json
 ```
 


### PR DESCRIPTION
Note that `hyperfine` no longer appears to have the argument `--export-json`, instead it is now just `--json`.