### PR TITLE
Implement shell bypassing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -184,6 +184,11 @@ fn build_app() -> App<'static> {
                 .help("Set the shell to use for executing benchmarked commands."),
         )
         .arg(
+            Arg::new("no-shell")
+                .long("no-shell")
+                .help("Execute benchmarked commands without a shell."),
+        )
+        .arg(
             Arg::new("ignore-failure")
                 .long("ignore-failure")
                 .short('i')

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -103,6 +103,14 @@ pub fn mean_shell_spawning_time(
     style: OutputStyleOption,
     show_output: bool,
 ) -> Result<TimingResult> {
+    if let Shell::None = shell {
+        return Ok(TimingResult {
+            time_real: 0.0,
+            time_user: 0.0,
+            time_system: 0.0,
+        });
+    }
+
     const COUNT: u64 = 50;
     let progress_bar = if style != OutputStyleOption::Disabled {
         Some(get_progress_bar(

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,9 +1,9 @@
-use std::process::{ExitStatus, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 
 use crate::options::Shell;
 use crate::timer::get_cpu_timer;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Error, Result};
 
 /// Used to indicate the result of running a command
 #[derive(Debug, Copy, Clone)]
@@ -67,10 +67,7 @@ fn run_shell_command(
     command: &str,
     shell: &Shell,
 ) -> Result<std::process::ExitStatus> {
-    shell
-        .command()
-        .arg("-c")
-        .arg(command)
+    prepare_shell_command(command, shell, &["-c"])?
         .env(
             "HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET",
             "X".repeat(rand::random::<usize>() % 4096usize),
@@ -90,13 +87,35 @@ fn run_shell_command(
     command: &str,
     shell: &Shell,
 ) -> Result<std::process::Child> {
-    shell
-        .command()
-        .arg("/C")
-        .arg(command)
+    prepare_shell_command(command, shell, &["/C"])?
         .stdin(Stdio::null())
         .stdout(stdout)
         .stderr(stderr)
         .spawn()
         .with_context(|| format!("Failed to run command '{}'", command))
+}
+
+fn prepare_shell_command(
+    command: &str,
+    shell: &Shell,
+    shell_extra_args: &[&str],
+) -> Result<std::process::Command> {
+    match shell.command() {
+        Some(mut shell_command) => {
+            shell_command.args(shell_extra_args).arg(command);
+            Ok(shell_command)
+        }
+        None => {
+            let mut tokens = shell_words::split(command)
+                .with_context(|| format!("Failed to parse command '{}", command))?
+                .into_iter();
+            if let Some(exec) = tokens.next() {
+                let mut shell_command = Command::new(exec);
+                shell_command.args(tokens);
+                Ok(shell_command)
+            } else {
+                Err(Error::msg("Failed to parse empty command"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
As commented on #336, I've made an initial patch to allow one to disable the shell intermediation, and just parse the command as a list of words (perhaps with quoting).

As @sharkdp mentioned, I currently use `--shell ''` to disable the shell, but that is quite ugly UX;  however I wanted to keep the patch as small as possible.

Also, given that Rust doesn't easily allow cross-compile I can't `cargo check --target ...windows...`, so although I've tried to get the code right on Windows most likely there is a compile error.

----

As mentioned in the issue at least in terms of outputs, it seems that `hyperfine` already handles the shell overhead and subtracts it from the outputs.  Thus this patch is mostly to speed-up the overall execution by not passing through the shell.  It shouldn't change the measured values.
