### PR TITLE
add progress bar duration for initial time measurement and shell spawn time

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -108,6 +108,7 @@ pub fn mean_shell_spawning_time(
             COUNT,
             "Measuring shell spawning time",
             style,
+            true,
         ))
     } else {
         None
@@ -270,6 +271,7 @@ pub fn run_benchmark(
                 options.warmup_count,
                 "Performing warmup runs",
                 options.output_style,
+                false,
             ))
         } else {
             None
@@ -299,6 +301,7 @@ pub fn run_benchmark(
             options.runs.min,
             "Initial time measurement",
             options.output_style,
+            true,
         ))
     } else {
         None
@@ -343,6 +346,22 @@ pub fn run_benchmark(
     all_succeeded = all_succeeded && success;
 
     // Re-configure the progress bar
+
+    // Clear the current progress bar and set up another with eta instead of duration
+    if let Some(bar) = progress_bar.as_ref() {
+        bar.finish_and_clear()
+    }
+    let progress_bar = if options.output_style != OutputStyleOption::Disabled {
+        Some(get_progress_bar(
+            options.runs.min,
+            "Current estimate: ",
+            options.output_style,
+            false,
+        ))
+    } else {
+        None
+    };
+
     if let Some(bar) = progress_bar.as_ref() {
         bar.set_length(count)
     }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -9,12 +9,23 @@ const TICK_SETTINGS: (&str, u64) = ("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ", 80);
 const TICK_SETTINGS: (&str, u64) = (r"+-x| ", 200);
 
 /// Return a pre-configured progress bar
-pub fn get_progress_bar(length: u64, msg: &str, option: OutputStyleOption) -> ProgressBar {
+pub fn get_progress_bar(
+    length: u64,
+    msg: &str,
+    option: OutputStyleOption,
+    show_duration: bool,
+) -> ProgressBar {
+    let progress_bar_template = if show_duration {
+        " {spinner} {msg:<30} {wide_bar}  AT {duration_precise}"
+    } else {
+        " {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"
+    };
+
     let progressbar_style = match option {
         OutputStyleOption::Basic | OutputStyleOption::Color => ProgressStyle::default_bar(),
         _ => ProgressStyle::default_spinner()
             .tick_chars(TICK_SETTINGS.0)
-            .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise}"),
+            .template(progress_bar_template),
     };
 
     let progress_bar = match option {


### PR DESCRIPTION
I used the suggested format in #416 **AT** instead of **ETA** for duration elapsed after the progress bar. Let me know if that should be changed to something else.

closes #416