### PR TITLE
Add support for one run with --runs=1

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -391,7 +391,10 @@ pub fn run_benchmark(
     // Compute statistical quantities
     let t_num = times_real.len();
     let t_mean = mean(&times_real);
-    let t_stddev = standard_deviation(&times_real, Some(t_mean));
+    let mut t_stddev = 0.0;
+    if times_real.len() != 1 {
+        t_stddev = standard_deviation(&times_real, Some(t_mean));
+    }
     let t_median = median(&times_real);
     let t_min = min(&times_real);
     let t_max = max(&times_real);
@@ -409,7 +412,16 @@ pub fn run_benchmark(
     let user_str = format_duration(user_mean, Some(time_unit));
     let system_str = format_duration(system_mean, Some(time_unit));
 
-    if options.output_style != OutputStyleOption::Disabled {
+    if options.output_style != OutputStyleOption::Disabled && times_real.len() == 1 {
+        println!(
+            "  Time ({} ≡):        {:>8}  {:>8}     [User: {}, System: {}]",
+            "abs".green().bold(),
+            mean_str.green().bold(),
+            "        ".to_string(), // alignment
+            user_str.blue(),
+            system_str.blue()
+        );
+    } else if options.output_style != OutputStyleOption::Disabled {
         println!(
             "  Time ({} ± {}):     {:>8} ± {:>8}    [User: {}, System: {}]",
             "mean".green().bold(),

--- a/src/benchmark_result.rs
+++ b/src/benchmark_result.rs
@@ -15,8 +15,8 @@ pub struct BenchmarkResult {
     /// The mean run time
     pub mean: Second,
 
-    /// The standard deviation of all run times
-    pub stddev: Second,
+    /// The standard deviation of all run times. Not available if only one run has been performed
+    pub stddev: Option<Second>,
 
     /// The median run time
     pub median: Second,
@@ -51,7 +51,7 @@ impl BenchmarkResult {
     pub fn new(
         command: String,
         mean: Second,
-        stddev: Second,
+        stddev: Option<Second>,
         median: Second,
         user: Second,
         system: Second,

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,7 +57,6 @@ impl Error for ParameterScanError {}
 
 #[derive(Debug)]
 pub enum OptionsError<'a> {
-    RunsBelowTwo,
     EmptyRunsRange,
     TooManyCommandNames(usize),
     UnexpectedCommandNameCount(usize, usize),
@@ -70,7 +69,6 @@ impl<'a> fmt::Display for OptionsError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             OptionsError::EmptyRunsRange => write!(f, "Empty runs range"),
-            OptionsError::RunsBelowTwo => write!(f, "Number of runs below two"),
             OptionsError::TooManyCommandNames(n) => {
                 write!(f, "Too many --command-name options: expected {} at most", n)
             }

--- a/src/export/asciidoc.rs
+++ b/src/export/asciidoc.rs
@@ -60,7 +60,7 @@ fn table_row(entry: &BenchmarkResult, unit: Unit) -> Vec<u8> {
          | {}…{}\n",
         entry.command.replace("|", "\\|"),
         form(entry.mean).0,
-        form(entry.stddev).0,
+        entry.stddev.map(|s| form(s).0).unwrap_or("?".into()),
         form(entry.min).0,
         form(entry.max).0
     )
@@ -84,14 +84,14 @@ fn test_asciidoc_header() {
 fn test_asciidoc_table_row() {
     use std::collections::BTreeMap;
     let result = BenchmarkResult::new(
-        String::from("sleep 1"), // command
-        0.10491992406666667,     // mean
-        0.00397851689425097,     // stddev
-        0.10491992406666667,     // median
-        0.005182013333333333,    // user
-        0.0,                     // system
-        0.1003342584,            // min
-        0.10745223440000001,     // max
+        String::from("sleep 1"),   // command
+        0.10491992406666667,       // mean
+        Some(0.00397851689425097), // stddev
+        0.10491992406666667,       // median
+        0.005182013333333333,      // user
+        0.0,                       // system
+        0.1003342584,              // min
+        0.10745223440000001,       // max
         vec![
             // times
             0.1003342584,
@@ -108,7 +108,7 @@ fn test_asciidoc_table_row() {
          | {}…{}\n",
         result.command,
         Unit::MilliSecond.format(result.mean),
-        Unit::MilliSecond.format(result.stddev),
+        Unit::MilliSecond.format(result.stddev.unwrap()),
         Unit::MilliSecond.format(result.min),
         Unit::MilliSecond.format(result.max)
     )
@@ -119,7 +119,7 @@ fn test_asciidoc_table_row() {
          | {}…{}\n",
         result.command,
         Unit::Second.format(result.mean),
-        Unit::Second.format(result.stddev),
+        Unit::Second.format(result.stddev.unwrap()),
         Unit::Second.format(result.min),
         Unit::Second.format(result.max)
     )
@@ -137,14 +137,14 @@ fn test_asciidoc_table_row() {
 fn test_asciidoc_table_row_command_escape() {
     use std::collections::BTreeMap;
     let result = BenchmarkResult::new(
-        String::from("sleep 1|"), // command
-        0.10491992406666667,      // mean
-        0.00397851689425097,      // stddev
-        0.10491992406666667,      // median
-        0.005182013333333333,     // user
-        0.0,                      // system
-        0.1003342584,             // min
-        0.10745223440000001,      // max
+        String::from("sleep 1|"),  // command
+        0.10491992406666667,       // mean
+        Some(0.00397851689425097), // stddev
+        0.10491992406666667,       // median
+        0.005182013333333333,      // user
+        0.0,                       // system
+        0.1003342584,              // min
+        0.10745223440000001,       // max
         vec![
             // times
             0.1003342584,
@@ -159,7 +159,7 @@ fn test_asciidoc_table_row_command_escape() {
          | {} ± {}\n\
          | {}…{}\n",
         Unit::Second.format(result.mean),
-        Unit::Second.format(result.stddev),
+        Unit::Second.format(result.stddev.unwrap()),
         Unit::Second.format(result.min),
         Unit::Second.format(result.max)
     )
@@ -179,7 +179,7 @@ fn test_asciidoc() {
         BenchmarkResult::new(
             String::from("FOO=1 BAR=2 command | 1"),
             1.0,
-            2.0,
+            Some(2.0),
             1.0,
             3.0,
             4.0,
@@ -197,7 +197,7 @@ fn test_asciidoc() {
         BenchmarkResult::new(
             String::from("FOO=1 BAR=7 command | 2"),
             11.0,
-            12.0,
+            Some(12.0),
             11.0,
             13.0,
             14.0,

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -33,7 +33,13 @@ impl Exporter for CsvExporter {
         for res in results {
             let mut fields = vec![Cow::Borrowed(res.command.as_bytes())];
             for f in &[
-                res.mean, res.stddev, res.median, res.user, res.system, res.min, res.max,
+                res.mean,
+                res.stddev.unwrap_or(0.0),
+                res.median,
+                res.user,
+                res.system,
+                res.min,
+                res.max,
             ] {
                 fields.push(Cow::Owned(f.to_string().into_bytes()))
             }
@@ -59,7 +65,7 @@ fn test_csv() {
         BenchmarkResult::new(
             String::from("FOO=one BAR=two command | 1"),
             1.0,
-            2.0,
+            Some(2.0),
             1.0,
             3.0,
             4.0,
@@ -77,7 +83,7 @@ fn test_csv() {
         BenchmarkResult::new(
             String::from("FOO=one BAR=seven command | 2"),
             11.0,
-            12.0,
+            Some(12.0),
             11.0,
             13.0,
             14.0,

--- a/src/export/markdown.rs
+++ b/src/export/markdown.rs
@@ -53,19 +53,27 @@ fn start_table(unit: Unit) -> Vec<u8> {
 fn add_table_row(dest: &mut Vec<u8>, entry: &BenchmarkResultWithRelativeSpeed, unit: Unit) {
     let result = &entry.result;
     let mean_str = format_duration_value(result.mean, Some(unit)).0;
-    let stddev_str = format_duration_value(result.stddev, Some(unit)).0;
+    let stddev_str = if let Some(stddev) = result.stddev {
+        format!(" ± {}", format_duration_value(stddev, Some(unit)).0)
+    } else {
+        "".into()
+    };
     let min_str = format_duration_value(result.min, Some(unit)).0;
     let max_str = format_duration_value(result.max, Some(unit)).0;
     let rel_str = format!("{:.2}", entry.relative_speed);
     let rel_stddev_str = if entry.is_fastest {
         "".into()
     } else {
-        format!(" ± {:.2}", entry.relative_speed_stddev)
+        if let Some(stddev) = entry.relative_speed_stddev {
+            format!(" ± {:.2}", stddev)
+        } else {
+            "".into()
+        }
     };
 
     dest.extend(
         format!(
-            "| `{command}` | {mean} ± {stddev} | {min} | {max} | {rel}{rel_stddev} |\n",
+            "| `{command}` | {mean}{stddev} | {min} | {max} | {rel}{rel_stddev} |\n",
             command = result.command.replace("|", "\\|"),
             mean = mean_str,
             stddev = stddev_str,
@@ -93,7 +101,7 @@ fn test_markdown_format_ms() {
         BenchmarkResult::new(
             String::from("sleep 0.1"),
             0.1057,                          // mean
-            0.0016,                          // std dev
+            Some(0.0016),                    // std dev
             0.1057,                          // median
             0.0009,                          // user_mean
             0.0011,                          // system_mean
@@ -106,7 +114,7 @@ fn test_markdown_format_ms() {
         BenchmarkResult::new(
             String::from("sleep 2"),
             2.0050,                          // mean
-            0.0020,                          // std dev
+            Some(0.0020),                    // std dev
             2.0050,                          // median
             0.0009,                          // user_mean
             0.0012,                          // system_mean
@@ -142,7 +150,7 @@ fn test_markdown_format_s() {
         BenchmarkResult::new(
             String::from("sleep 2"),
             2.0050,                          // mean
-            0.0020,                          // std dev
+            Some(0.0020),                    // std dev
             2.0050,                          // median
             0.0009,                          // user_mean
             0.0012,                          // system_mean
@@ -155,7 +163,7 @@ fn test_markdown_format_s() {
         BenchmarkResult::new(
             String::from("sleep 0.1"),
             0.1057,                          // mean
-            0.0016,                          // std dev
+            Some(0.0016),                    // std dev
             0.1057,                          // median
             0.0009,                          // user_mean
             0.0011,                          // system_mean
@@ -190,7 +198,7 @@ fn test_markdown_format_time_unit_s() {
         BenchmarkResult::new(
             String::from("sleep 0.1"),
             0.1057,                          // mean
-            0.0016,                          // std dev
+            Some(0.0016),                    // std dev
             0.1057,                          // median
             0.0009,                          // user_mean
             0.0011,                          // system_mean
@@ -203,7 +211,7 @@ fn test_markdown_format_time_unit_s() {
         BenchmarkResult::new(
             String::from("sleep 2"),
             2.0050,                          // mean
-            0.0020,                          // std dev
+            Some(0.0020),                    // std dev
             2.0050,                          // median
             0.0009,                          // user_mean
             0.0012,                          // system_mean
@@ -244,7 +252,7 @@ fn test_markdown_format_time_unit_ms() {
         BenchmarkResult::new(
             String::from("sleep 2"),
             2.0050,                          // mean
-            0.0020,                          // std dev
+            Some(0.0020),                    // std dev
             2.0050,                          // median
             0.0009,                          // user_mean
             0.0012,                          // system_mean
@@ -257,7 +265,7 @@ fn test_markdown_format_time_unit_ms() {
         BenchmarkResult::new(
             String::from("sleep 0.1"),
             0.1057,                          // mean
-            0.0016,                          // std dev
+            Some(0.0016),                    // std dev
             0.1057,                          // median
             0.0009,                          // user_mean
             0.0011,                          // system_mean

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,16 +171,8 @@ fn build_hyperfine_options<'a>(
     }
 
     match (min_runs, max_runs) {
-        (Some(min), _) if min < 2 => {
-            // We need at least two runs to compute a variance.
-            return Err(OptionsError::RunsBelowTwo);
-        }
         (Some(min), None) => {
             options.runs.min = min;
-        }
-        (_, Some(max)) if max < 2 => {
-            // We need at least two runs to compute a variance.
-            return Err(OptionsError::RunsBelowTwo);
         }
         (None, Some(max)) => {
             // Since the minimum was not explicit we lower it if max is below the default min.

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,9 +61,13 @@ pub fn write_benchmark_comparison(results: &[BenchmarkResult]) {
 
         for item in others {
             println!(
-                "{} ± {} times faster than '{}'",
+                "{}{} times faster than '{}'",
                 format!("{:8.2}", item.relative_speed).bold().green(),
-                format!("{:.2}", item.relative_speed_stddev).green(),
+                if let Some(stddev) = item.relative_speed_stddev {
+                    format!(" ± {}", format!("{:.2}", stddev).green())
+                } else {
+                    "".into()
+                },
                 &item.result.command.magenta()
             );
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -23,12 +23,12 @@ fn hyperfine_runs_successfully() {
 }
 
 #[test]
-fn at_least_two_runs_are_required() {
+fn one_run_is_supported() {
     hyperfine()
         .arg("--runs=1")
         .arg("echo dummy benchmark")
         .assert()
-        .failure();
+        .success();
 }
 
 struct ExecutionOrderTest {
@@ -107,6 +107,17 @@ impl Default for ExecutionOrderTest {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[test]
+fn benchmarks_are_executed_sequentially_one() {
+    ExecutionOrderTest::new()
+        .arg("--runs=1")
+        .command("command 1")
+        .command("command 2")
+        .expect_output("command 1")
+        .expect_output("command 2")
+        .run();
 }
 
 #[test]


### PR DESCRIPTION
Extend the --runs=N option added in d78c33b (Added options to specify
the max/exact numbers of runs., 2018-09-09) to support --runs=1
instead of dying with a usage error.

This is useful to do ad-hoc testing of your commands while they might
still have syntax errors, or just for doing one run where you don't
care about the stddev.

Before:

    $ /usr/bin/hyperfine -s basic -r 1 -L n 5,10 'sleep 0.{n}'
    Error: Number of runs below two

After (-s basic) also works:

    $ hyperfine -r 1 -L n 5,10 'sleep 0.{n}'
    Benchmark 1: sleep 0.5
      Time (abs ≡):        500.6 ms               [User: 0.6 ms, System: 0.0 ms]

    Benchmark 2: sleep 0.10
      Time (abs ≡):        100.8 ms               [User: 0.7 ms, System: 0.0 ms]

    Summary
      'sleep 0.10' ran
        4.97 ± 0.00 times faster than 'sleep 0.5'

This likewise combines correctly with -m and -M, probably not very
useful, but if you're tweaking an existing command-line:

    $ hyperfine -m 1 -M 1 -L n 5,10 'sleep 0.{n}'
    Benchmark 1: sleep 0.5
      Time (abs ≡):        500.6 ms               [User: 0.5 ms, System: 0.0 ms]

    Benchmark 2: sleep 0.10
      Time (abs ≡):        100.6 ms               [User: 0.6 ms, System: 0.0 ms]

    Summary
      'sleep 0.10' ran
        4.98 ± 0.00 times faster than 'sleep 0.5'

The "± 0.00" output in "faster than" should probably be adjusted too,
or we could keep it for consistency. I didn't implement that because
this is the first time I do anything in Rust, and I ran out of
template to copy when wanting to quickly implement this in
write_benchmark_comparison() in main.rs.