### PR TITLE
Export orgmode runs with markup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,6 +249,13 @@ fn build_command() -> Command<'static> {
                 .help("Export the timing summary statistics as a Emacs org-mode table to the given FILE."),
         )
         .arg(
+            Arg::new("export-orgmode-runs")
+                .long("export-orgmode-runs")
+                .takes_value(true)
+                .value_name("FILE")
+                .help("Export the timings of individual runs as a Emacs org-mode table to the given FILE."),
+        )
+        .arg(
             Arg::new("show-output")
                 .long("show-output")
                 .conflicts_with("style")

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -13,6 +13,7 @@ use self::csv::CsvExporter;
 use self::json::JsonExporter;
 use self::markdown::MarkdownExporter;
 use self::orgmode::OrgmodeExporter;
+use self::orgmode::OrgmodeRunsExporter;
 
 use crate::benchmark::benchmark_result::BenchmarkResult;
 use crate::util::units::Unit;
@@ -37,6 +38,7 @@ pub enum ExportType {
 
     /// Emacs org-mode tables
     Orgmode,
+    OrgmodeRuns,
 }
 
 /// Interface for different exporters.
@@ -73,6 +75,7 @@ impl ExportManager {
             add_exporter("export-csv", ExportType::Csv)?;
             add_exporter("export-markdown", ExportType::Markdown)?;
             add_exporter("export-orgmode", ExportType::Orgmode)?;
+            add_exporter("export-orgmode-runs", ExportType::OrgmodeRuns)?;
         }
         Ok(export_manager)
     }
@@ -88,6 +91,7 @@ impl ExportManager {
             ExportType::Json => Box::new(JsonExporter::default()),
             ExportType::Markdown => Box::new(MarkdownExporter::default()),
             ExportType::Orgmode => Box::new(OrgmodeExporter::default()),
+            ExportType::OrgmodeRuns => Box::new(OrgmodeRunsExporter::default()),
         };
         self.exporters.push(ExporterWithFilename {
             exporter,

--- a/src/export/orgmode.rs
+++ b/src/export/orgmode.rs
@@ -1,5 +1,7 @@
 use super::markup::Alignment;
-use crate::export::markup::MarkupExporter;
+use crate::export::{markup::MarkupExporter, BenchmarkResult, Exporter};
+use crate::util::units::Unit;
+use anyhow::Result;
 
 #[derive(Default)]
 pub struct OrgmodeExporter {}
@@ -19,6 +21,17 @@ impl MarkupExporter for OrgmodeExporter {
 
     fn command(&self, cmd: &str) -> String {
         format!("={}=", cmd)
+    }
+}
+
+#[derive(Default)]
+pub struct OrgmodeRunsExporter(OrgmodeExporter);
+
+impl Exporter for OrgmodeRunsExporter {
+    fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
+        let unit = Unit::Second;
+        let table = self.0.table_runs(results, unit);
+        Ok(table.as_bytes().to_vec())
     }
 }
 
@@ -164,6 +177,108 @@ fn test_orgmode_format_s() {
 ",
         cfg_test_table_header("s".to_string())
     );
+
+    assert_eq!(expect, actual);
+}
+
+/// This test demonstrates the exporting of all individual timings of all runs
+/// without any parameters.
+#[test]
+fn test_orgmode_format_runs() {
+    use std::collections::BTreeMap;
+    let exporter = OrgmodeRunsExporter::default();
+
+    let results = vec![
+        BenchmarkResult {
+            command: String::from("sleep 2"),
+            mean: 2.0050,
+            stddev: Some(0.0020),
+            median: 2.0050,
+            user: 0.0009,
+            system: 0.0012,
+            min: 2.0020,
+            max: 2.0080,
+            times: Some(vec![2.0, 2.0, 2.0]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::new(),
+        },
+        BenchmarkResult {
+            command: String::from("sleep 0.1"),
+            mean: 0.1057,
+            stddev: Some(0.0016),
+            median: 0.1057,
+            user: 0.0009,
+            system: 0.0011,
+            min: 0.1023,
+            max: 0.1080,
+            times: Some(vec![0.1, 0.1, 0.1]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::new(),
+        },
+    ];
+
+    let actual =
+        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let expect = "| Command  |  Sample |  Time [s] |  Run |  Parameters |
+|--+--+--+--+--|
+| =sleep 2=  |  1 |  2.000000000 |  ok |  - |
+| =sleep 2=  |  2 |  2.000000000 |  ok |  - |
+| =sleep 2=  |  3 |  2.000000000 |  ok |  - |
+| =sleep 0.1=  |  4 |  0.100000000 |  ok |  - |
+| =sleep 0.1=  |  5 |  0.100000000 |  ok |  - |
+| =sleep 0.1=  |  6 |  0.100000000 |  ok |  - |
+";
+
+    assert_eq!(expect, actual);
+}
+
+/// This test demonstrates the exporting of all individual timings of all runs
+/// with some parameters.
+#[test]
+fn test_orgmode_format_runs_parameters() {
+    use std::collections::BTreeMap;
+    let exporter = OrgmodeRunsExporter::default();
+
+    let results = vec![
+        BenchmarkResult {
+            command: String::from("sleep 0.1"),
+            mean: 0.1057,
+            stddev: Some(0.0016),
+            median: 0.1057,
+            user: 0.0009,
+            system: 0.0011,
+            min: 0.1023,
+            max: 0.1080,
+            times: Some(vec![0.1, 0.1, 0.1]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::from([("time".to_string(), "0.1".to_string())]),
+        },
+        BenchmarkResult {
+            command: String::from("sleep 2"),
+            mean: 2.0050,
+            stddev: Some(0.0020),
+            median: 2.0050,
+            user: 0.0009,
+            system: 0.0012,
+            min: 2.0020,
+            max: 2.0080,
+            times: Some(vec![2.0, 2.0, 2.0]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::from([("time".to_string(), "2".to_string())]),
+        },
+    ];
+
+    let actual =
+        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let expect = "| Command  |  Sample |  Time [s] |  Run |  Parameters |
+|--+--+--+--+--|
+| =sleep 0.1=  |  1 |  0.100000000 |  ok |  time=0.1 |
+| =sleep 0.1=  |  2 |  0.100000000 |  ok |  time=0.1 |
+| =sleep 0.1=  |  3 |  0.100000000 |  ok |  time=0.1 |
+| =sleep 2=  |  4 |  2.000000000 |  ok |  time=2 |
+| =sleep 2=  |  5 |  2.000000000 |  ok |  time=2 |
+| =sleep 2=  |  6 |  2.000000000 |  ok |  time=2 |
+";
 
     assert_eq!(expect, actual);
 }


### PR DESCRIPTION
This PR introduces the following changes:

* improvement of `markup.rs` by providing a new individual timings data generation and provided exporter support for Emacs org-mode table emitting
* added new command line argument `--export-orgmode-runs <FILE>`
* ~~depends on #491~~ 
* depends on #510
* depends on #511