### PR TITLE
Export markdown runs with markup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,6 +249,13 @@ fn build_command() -> Command<'static> {
                 .help("Export the timing summary statistics as a Emacs org-mode table to the given FILE."),
         )
         .arg(
+            Arg::new("export-orgmode-runs")
+                .long("export-orgmode-runs")
+                .takes_value(true)
+                .value_name("FILE")
+                .help("Export the timings of individual runs as a Emacs org-mode table to the given FILE."),
+        )
+        .arg(
             Arg::new("show-output")
                 .long("show-output")
                 .conflicts_with("style")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,6 +242,13 @@ fn build_command() -> Command<'static> {
                 .help("Export the timing summary statistics as a Markdown table to the given FILE."),
         )
         .arg(
+            Arg::new("export-markdown-runs")
+                .long("export-markdown-runs")
+                .takes_value(true)
+                .value_name("FILE")
+                .help("Export the timings of individual runs as a Markdown table to the given FILE."),
+        )
+        .arg(
             Arg::new("export-orgmode")
                 .long("export-orgmode")
                 .takes_value(true)

--- a/src/export/markup.rs
+++ b/src/export/markup.rs
@@ -1,4 +1,3 @@
-use crate::benchmark::benchmark_result::BenchmarkResult;
 use crate::benchmark::relative_speed::BenchmarkResultWithRelativeSpeed;
 use crate::benchmark::{benchmark_result::BenchmarkResult, relative_speed};
 use crate::output::format::format_duration_value;

--- a/src/export/markup.rs
+++ b/src/export/markup.rs
@@ -1,3 +1,4 @@
+use crate::benchmark::benchmark_result::BenchmarkResult;
 use crate::benchmark::relative_speed::BenchmarkResultWithRelativeSpeed;
 use crate::benchmark::{benchmark_result::BenchmarkResult, relative_speed};
 use crate::output::format::format_duration_value;
@@ -144,6 +145,7 @@ pub trait MarkupExporter {
 
         table
     }
+
     fn table_row(&self, cells: &[&str]) -> String;
 
     fn table_divider(&self, cell_aligmnents: &[Alignment]) -> String;

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -12,6 +12,7 @@ use self::asciidoc::AsciidocExporter;
 use self::csv::CsvExporter;
 use self::json::JsonExporter;
 use self::markdown::MarkdownExporter;
+use self::markdown::MarkdownRunsExporter;
 use self::orgmode::OrgmodeExporter;
 use self::orgmode::OrgmodeRunsExporter;
 
@@ -33,8 +34,9 @@ pub enum ExportType {
     /// JSON format
     Json,
 
-    /// Markdown table
+    /// Markdown tables
     Markdown,
+    MarkdownRuns,
 
     /// Emacs org-mode tables
     Orgmode,
@@ -74,6 +76,7 @@ impl ExportManager {
             add_exporter("export-json", ExportType::Json)?;
             add_exporter("export-csv", ExportType::Csv)?;
             add_exporter("export-markdown", ExportType::Markdown)?;
+            add_exporter("export-markdown-runs", ExportType::MarkdownRuns)?;
             add_exporter("export-orgmode", ExportType::Orgmode)?;
             add_exporter("export-orgmode-runs", ExportType::OrgmodeRuns)?;
         }
@@ -90,6 +93,7 @@ impl ExportManager {
             ExportType::Csv => Box::new(CsvExporter::default()),
             ExportType::Json => Box::new(JsonExporter::default()),
             ExportType::Markdown => Box::new(MarkdownExporter::default()),
+            ExportType::MarkdownRuns => Box::new(MarkdownRunsExporter::default()),
             ExportType::Orgmode => Box::new(OrgmodeExporter::default()),
             ExportType::OrgmodeRuns => Box::new(OrgmodeRunsExporter::default()),
         };

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -13,6 +13,7 @@ use self::csv::CsvExporter;
 use self::json::JsonExporter;
 use self::markdown::MarkdownExporter;
 use self::orgmode::OrgmodeExporter;
+use self::orgmode::OrgmodeRunsExporter;
 
 use crate::benchmark::benchmark_result::BenchmarkResult;
 use crate::util::units::Unit;
@@ -37,6 +38,7 @@ pub enum ExportType {
 
     /// Emacs org-mode tables
     Orgmode,
+    OrgmodeRuns,
 }
 
 /// Interface for different exporters.
@@ -73,6 +75,7 @@ impl ExportManager {
             add_exporter("export-csv", ExportType::Csv)?;
             add_exporter("export-markdown", ExportType::Markdown)?;
             add_exporter("export-orgmode", ExportType::Orgmode)?;
+            add_exporter("export-orgmode-runs", ExportType::OrgmodeRuns)?;
         }
         Ok(export_manager)
     }
@@ -88,6 +91,7 @@ impl ExportManager {
             ExportType::Json => Box::new(JsonExporter::default()),
             ExportType::Markdown => Box::new(MarkdownExporter::default()),
             ExportType::Orgmode => Box::new(OrgmodeExporter::default()),
+            ExportType::OrgmodeRuns => Box::new(OrgmodeRunsExporter::default()),
         };
         self.exporters.push(ExporterWithFilename {
             exporter,

--- a/src/export/orgmode.rs
+++ b/src/export/orgmode.rs
@@ -35,6 +35,19 @@ impl Exporter for OrgmodeRunsExporter {
     }
 }
 
+#[derive(Default)]
+pub struct OrgmodeRunsExporter {}
+
+impl Exporter for OrgmodeRunsExporter {
+    fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
+        let unit = Unit::Second;
+
+        let formatter = OrgmodeFormatter::default();
+        let table = formatter.table_runs(results, unit);
+        Ok(table.as_bytes().to_vec())
+    }
+}
+
 /// Check Emacs org-mode data row formatting
 #[test]
 fn test_orgmode_formatter_table_data() {

--- a/src/export/orgmode.rs
+++ b/src/export/orgmode.rs
@@ -35,19 +35,6 @@ impl Exporter for OrgmodeRunsExporter {
     }
 }
 
-#[derive(Default)]
-pub struct OrgmodeRunsExporter {}
-
-impl Exporter for OrgmodeRunsExporter {
-    fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
-        let unit = Unit::Second;
-
-        let formatter = OrgmodeFormatter::default();
-        let table = formatter.table_runs(results, unit);
-        Ok(table.as_bytes().to_vec())
-    }
-}
-
 /// Check Emacs org-mode data row formatting
 #[test]
 fn test_orgmode_formatter_table_data() {

--- a/src/export/orgmode.rs
+++ b/src/export/orgmode.rs
@@ -1,5 +1,7 @@
 use super::markup::Alignment;
-use crate::export::markup::MarkupExporter;
+use crate::export::{markup::MarkupExporter, BenchmarkResult, Exporter};
+use crate::util::units::Unit;
+use anyhow::Result;
 
 #[derive(Default)]
 pub struct OrgmodeExporter {}
@@ -19,6 +21,17 @@ impl MarkupExporter for OrgmodeExporter {
 
     fn command(&self, cmd: &str) -> String {
         format!("={}=", cmd)
+    }
+}
+
+#[derive(Default)]
+pub struct OrgmodeRunsExporter(OrgmodeExporter);
+
+impl Exporter for OrgmodeRunsExporter {
+    fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
+        let unit = Unit::Second;
+        let table = self.0.table_runs(results, unit);
+        Ok(table.as_bytes().to_vec())
     }
 }
 
@@ -164,6 +177,108 @@ fn test_orgmode_format_s() {
 ",
         cfg_test_table_header("s".to_string())
     );
+
+    assert_eq!(expect, actual);
+}
+
+/// This test demonstrates the exporting of all individual timings of all runs
+/// without any parameters.
+#[test]
+fn test_orgmode_format_runs() {
+    use std::collections::BTreeMap;
+    let exporter = OrgmodeRunsExporter::default();
+
+    let results = vec![
+        BenchmarkResult {
+            command: String::from("sleep 2"),
+            mean: 2.0050,
+            stddev: Some(0.0020),
+            median: 2.0050,
+            user: 0.0009,
+            system: 0.0012,
+            min: 2.0020,
+            max: 2.0080,
+            times: Some(vec![2.0, 2.0, 2.0]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::new(),
+        },
+        BenchmarkResult {
+            command: String::from("sleep 0.1"),
+            mean: 0.1057,
+            stddev: Some(0.0016),
+            median: 0.1057,
+            user: 0.0009,
+            system: 0.0011,
+            min: 0.1023,
+            max: 0.1080,
+            times: Some(vec![0.1, 0.1, 0.1]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::new(),
+        },
+    ];
+
+    let actual =
+        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let expect = "| Command  |  Sample |  Time [s] |  Run |  Parameters |
+|--+--+--+--+--|
+| =sleep 2=  |  1 |  2.000000000 |  ok |  - |
+| =sleep 2=  |  2 |  2.000000000 |  ok |  - |
+| =sleep 2=  |  3 |  2.000000000 |  ok |  - |
+| =sleep 0.1=  |  4 |  0.100000000 |  ok |  - |
+| =sleep 0.1=  |  5 |  0.100000000 |  ok |  - |
+| =sleep 0.1=  |  6 |  0.100000000 |  ok |  - |
+";
+
+    assert_eq!(expect, actual);
+}
+
+/// This test demonstrates the exporting of all individual timings of all runs
+/// with some parameters.
+#[test]
+fn test_orgmode_format_runs_parameters() {
+    use std::collections::BTreeMap;
+    let exporter = OrgmodeRunsExporter::default();
+
+    let results = vec![
+        BenchmarkResult {
+            command: String::from("sleep 0.1"),
+            mean: 0.1057,
+            stddev: Some(0.0016),
+            median: 0.1057,
+            user: 0.0009,
+            system: 0.0011,
+            min: 0.1023,
+            max: 0.1080,
+            times: Some(vec![0.1, 0.1, 0.1]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::from([("time".to_string(), "0.1".to_string())]),
+        },
+        BenchmarkResult {
+            command: String::from("sleep 2"),
+            mean: 2.0050,
+            stddev: Some(0.0020),
+            median: 2.0050,
+            user: 0.0009,
+            system: 0.0012,
+            min: 2.0020,
+            max: 2.0080,
+            times: Some(vec![2.0, 2.0, 2.0]),
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::from([("time".to_string(), "2".to_string())]),
+        },
+    ];
+
+    let actual =
+        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let expect = "| Command  |  Sample |  Time [s] |  Run |  Parameters |
+|--+--+--+--+--|
+| =sleep 0.1=  |  1 |  0.100000000 |  ok |  time=0.1 |
+| =sleep 0.1=  |  2 |  0.100000000 |  ok |  time=0.1 |
+| =sleep 0.1=  |  3 |  0.100000000 |  ok |  time=0.1 |
+| =sleep 2=  |  4 |  2.000000000 |  ok |  time=2 |
+| =sleep 2=  |  5 |  2.000000000 |  ok |  time=2 |
+| =sleep 2=  |  6 |  2.000000000 |  ok |  time=2 |
+";
 
     assert_eq!(expect, actual);
 }


### PR DESCRIPTION
This PR introduces the following changes:

* provides individual timings of runs export as Markdown tables by reusing the `markup.rs` functionality provided in the PR https://github.com/sharkdp/hyperfine/pull/492
* adds new command line argument `--export-markdown-runs <FILE>`
 