### PR TITLE
Allow multiple --setup arguments to be specified

### DIFF
--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -63,23 +63,11 @@ impl<'a> Benchmark<'a> {
     }
 
     /// Run the command specified by `--setup`.
-    fn run_setup_command(
-        &self,
-        parameters: impl IntoIterator<Item = ParameterNameAndValue<'a>>,
-    ) -> Result<TimingResult> {
-        let command = self
-            .options
-            .setup_command
-            .as_ref()
-            .map(|setup_command| Command::new_parametrized(None, setup_command, parameters));
-
+    fn run_setup_command(&self, command: &Command<'_>) -> Result<TimingResult> {
         let error_output = "The setup command terminated with a non-zero exit code. \
                             Append ' || true' to the command if you are sure that this can be ignored.";
 
-        Ok(command
-            .map(|cmd| self.run_intermediate_command(&cmd, error_output))
-            .transpose()?
-            .unwrap_or_default())
+        self.run_intermediate_command(command, error_output)
     }
 
     /// Run the command specified by `--cleanup`.
@@ -147,7 +135,27 @@ impl<'a> Benchmark<'a> {
                 .transpose()
         };
 
-        self.run_setup_command(self.command.get_parameters().iter().cloned())?;
+        let setup_command = self.options.setup_command.as_ref().map(|values| {
+            let setup_command = if values.len() == 1 {
+                &values[0]
+            } else {
+                &values[self.number]
+            };
+            Command::new_parametrized(
+                None,
+                setup_command,
+                self.command.get_parameters().iter().cloned(),
+            )
+        });
+        
+        let run_setup_command = || {            
+            setup_command
+                .as_ref()
+                .map(|cmd| self.run_setup_command(cmd))
+                .transpose()
+        };
+
+        run_setup_command()?;
 
         // Warmup phase
         if self.options.warmup_count > 0 {

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -147,8 +147,8 @@ impl<'a> Benchmark<'a> {
                 self.command.get_parameters().iter().cloned(),
             )
         });
-        
-        let run_setup_command = || {            
+
+        let run_setup_command = || {
             setup_command
                 .as_ref()
                 .map(|cmd| self.run_setup_command(cmd))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,7 @@ fn build_command() -> Command<'static> {
                 .long("setup")
                 .short('s')
                 .takes_value(true)
+                .multiple_occurrences(true)
                 .number_of_values(1)
                 .value_name("CMD")
                 .help(

--- a/src/options.rs
+++ b/src/options.rs
@@ -162,8 +162,8 @@ pub struct Options {
     /// Command(s) to run before each timing run
     pub preparation_command: Option<Vec<String>>,
 
-    /// Command to run before each *batch* of timing runs, i.e. before each individual benchmark
-    pub setup_command: Option<String>,
+    /// Command(s) to run before each *batch* of timing runs, i.e. before each individual benchmark
+    pub setup_command: Option<Vec<String>>,
 
     /// Command to run after each *batch* of timing runs, i.e. after each individual benchmark
     pub cleanup_command: Option<String>,
@@ -241,7 +241,9 @@ impl Options {
             (None, None) => {}
         };
 
-        options.setup_command = matches.value_of("setup").map(String::from);
+        options.setup_command = matches
+            .values_of("setup")
+            .map(|values| values.map(String::from).collect::<Vec<String>>());
 
         options.preparation_command = matches
             .values_of("prepare")
@@ -314,6 +316,15 @@ impl Options {
                 preparation_command.len() <= 1
                     || commands.num_commands() == preparation_command.len(),
                 "The '--prepare' option has to be provided just once or N times, where N is the \
+             number of benchmark commands."
+            );
+        }
+
+        if let Some(setup_command) = &self.setup_command {
+            ensure!(
+                setup_command.len() <= 1
+                    || commands.num_commands() == setup_command.len(),
+                "The '--setup' option has to be provided just once or N times, where N is the \
              number of benchmark commands."
             );
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -322,8 +322,7 @@ impl Options {
 
         if let Some(setup_command) = &self.setup_command {
             ensure!(
-                setup_command.len() <= 1
-                    || commands.num_commands() == setup_command.len(),
+                setup_command.len() <= 1 || commands.num_commands() == setup_command.len(),
                 "The '--setup' option has to be provided just once or N times, where N is the \
              number of benchmark commands."
             );

--- a/tests/execution_order_tests.rs
+++ b/tests/execution_order_tests.rs
@@ -276,3 +276,20 @@ fn multiple_parameter_values() {
         .expect_output("command 3 b")
         .run();
 }
+
+#[test]
+fn multiple_setup_commands_are_executed_for_each_block() {
+    ExecutionOrderTest::new()
+        .arg("--runs=2")
+        .setup("setup 1")
+        .command("command 1")
+        .setup("setup 2")
+        .command("command 2")
+        .expect_output("setup 1")
+        .expect_output("command 1")
+        .expect_output("command 1")
+        .expect_output("setup 2")
+        .expect_output("command 2")
+        .expect_output("command 2")
+        .run();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -319,3 +319,28 @@ fn performs_all_benchmarks_in_parameter_scan() {
                 .and(predicate::str::contains("Benchmark 5: sleep 50").not()),
         );
 }
+
+#[test]
+fn fails_with_wrong_number_of_setup_options() {
+    hyperfine()
+        .arg("--runs=1")
+        .arg("--setup=echo a")
+        .arg("--setup=echo b")
+        .arg("echo a")
+        .arg("echo b")
+        .assert()
+        .success();
+
+    hyperfine()
+        .arg("--runs=1")
+        .arg("--setup=echo a")
+        .arg("--setup=echo b")
+        .arg("echo a")
+        .arg("echo b")
+        .arg("echo c")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "The '--setup' option has to be provided",
+        ));
+}


### PR DESCRIPTION
Now --setup behaves identical to --prepare, except
setups run once before each batch, prepare run before each cmd