### PR TITLE
Use cross to build x86_64-unknown-linux-gnu executables

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -60,7 +60,7 @@ jobs:
           - { target: x86_64-apple-darwin         , os: macos-10.15                   }
           - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                  }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
     steps:
     - name: Checkout source code


### PR DESCRIPTION
We do this in order to link against older versions of glibc.

hopefully closes #508