### PR TITLE
Remove extraneous characters from code sample

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,9 +2,9 @@ This folder contains scripts that can be used in combination with hyperfines `--
 
 ### Example:
 
-``` bash
-> hyperfine 'sleep 0.020' 'sleep 0.021' 'sleep 0.022' --export-json sleep.json
-> python plot_whisker.py sleep.json
+```bash
+hyperfine 'sleep 0.020' 'sleep 0.021' 'sleep 0.022' --export-json sleep.json
+python plot_whisker.py sleep.json
 ```
 
 ### Pre-requisites


### PR DESCRIPTION
The first code sample in `scripts/README.md` includes `> ` on each line as an indicator that it is a shell command. GitHub includes a helpful *copy to clipboard* function demonstrated below:

![2022-05-19 18 01 51](https://user-images.githubusercontent.com/8844992/169423176-df84a333-0531-45c5-b93e-c371e4497969.gif)

The `> ` indicators are copied by this as well. When the code sample is pasted into a shell it produces an error, in bash (3.2.57), zsh (5.8) and fish (3.4.1).

It is possible to workaround this by manually copying and pasting each line without the `> ` indicators.

Removing the `> ` indicators from the code sample allows it to be copied and pasted into all three of the above-listed shells where the commands can complete successfully.

This pull request updates the code sample in `scripts/README.md` to remove the `> ` indicators.