### PR TITLE
Implement slowness checking and --reference flag to use a command as a reference when printing or exporting summary

### DIFF
--- a/src/benchmark/relative_speed.rs
+++ b/src/benchmark/relative_speed.rs
@@ -8,20 +8,26 @@ pub struct BenchmarkResultWithRelativeSpeed<'a> {
     pub result: &'a BenchmarkResult,
     pub relative_speed: Scalar,
     pub relative_speed_stddev: Option<Scalar>,
-    pub is_fastest: bool,
+    pub is_reference: bool,
+    pub is_faster: bool,
 }
 
 pub fn compare_mean_time(l: &BenchmarkResult, r: &BenchmarkResult) -> Ordering {
     l.mean.partial_cmp(&r.mean).unwrap_or(Ordering::Equal)
 }
 
-pub fn compute(results: &[BenchmarkResult]) -> Option<Vec<BenchmarkResultWithRelativeSpeed>> {
-    let fastest: &BenchmarkResult = results
+pub fn fastest(results: &[BenchmarkResult]) -> &BenchmarkResult {
+    results
         .iter()
         .min_by(|&l, &r| compare_mean_time(l, r))
-        .expect("at least one benchmark result");
+        .expect("at least one benchmark result")
+}
 
-    if fastest.mean == 0.0 {
+pub fn compute<'a>(
+    reference: &'a BenchmarkResult,
+    results: &'a [BenchmarkResult],
+) -> Option<Vec<BenchmarkResultWithRelativeSpeed<'a>>> {
+    if reference.mean == 0.0 {
         return None;
     }
 
@@ -29,25 +35,34 @@ pub fn compute(results: &[BenchmarkResult]) -> Option<Vec<BenchmarkResultWithRel
         results
             .iter()
             .map(|result| {
-                let ratio = result.mean / fastest.mean;
+                let is_reference = result == reference;
+                let is_faster = result.mean >= reference.mean;
 
-                // https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
-                // Covariance asssumed to be 0, i.e. variables are assumed to be independent
-                let ratio_stddev = match (result.stddev, fastest.stddev) {
-                    (Some(result_stddev), Some(fastest_stddev)) => Some(
-                        ratio
-                            * ((result_stddev / result.mean).powi(2)
-                                + (fastest_stddev / fastest.mean).powi(2))
-                            .sqrt(),
-                    ),
-                    _ => None,
+                let ratio = if is_faster {
+                    result.mean / reference.mean
+                } else {
+                    reference.mean / result.mean
                 };
+
+                // https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae
+                // Covariance asssumed to be 0, i.e. variables are assumed to be independent
+                let ratio_stddev =
+                    (result.stddev)
+                        .zip(reference.stddev)
+                        .map(|(result_stddev, fastest_stddev)| {
+                            let (a, b) = (
+                                (result_stddev / result.mean),
+                                (fastest_stddev / reference.mean),
+                            );
+                            ratio * (a.powi(2) + b.powi(2)).sqrt()
+                        });
 
                 BenchmarkResultWithRelativeSpeed {
                     result,
                     relative_speed: ratio,
                     relative_speed_stddev: ratio_stddev,
-                    is_fastest: result == fastest,
+                    is_reference,
+                    is_faster,
                 }
             })
             .collect(),
@@ -83,7 +98,7 @@ fn test_compute_relative_speed() {
         create_result("cmd3", 5.0),
     ];
 
-    let annotated_results = compute(&results).unwrap();
+    let annotated_results = compute(fastest(&results), &results).unwrap();
 
     assert_relative_eq!(1.5, annotated_results[0].relative_speed);
     assert_relative_eq!(1.0, annotated_results[1].relative_speed);
@@ -94,7 +109,7 @@ fn test_compute_relative_speed() {
 fn test_compute_relative_speed_for_zero_times() {
     let results = vec![create_result("cmd1", 1.0), create_result("cmd2", 0.0)];
 
-    let annotated_results = compute(&results);
+    let annotated_results = compute(fastest(&results), &results);
 
     assert!(annotated_results.is_none());
 }

--- a/src/benchmark/scheduler.rs
+++ b/src/benchmark/scheduler.rs
@@ -89,13 +89,14 @@ impl<'a> Scheduler<'a> {
             for item in others {
                 let comparator = if item.is_faster { "faster" } else { "slower" };
                 println!(
-                    "{}{} times {comparator} than '{}'", // slower than?????
+                    "{}{} times {} than '{}'",
                     format!("{:8.2}", item.relative_speed).bold().green(),
                     if let Some(stddev) = item.relative_speed_stddev {
                         format!(" ± {}", format!("{:.2}", stddev).green())
                     } else {
                         "".into()
                     },
+                    comparator,
                     &item.result.command.magenta()
                 );
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,15 @@ fn build_command() -> Command<'static> {
                        hyperfine automatically determines the number of runs."),
         )
         .arg(
+            Arg::new("reference")
+                .long("reference")
+                .short('R')
+                .takes_value(true)
+                .number_of_values(1)
+                .value_name("CMD")
+                .help("The reference command to measure the results against."),
+        )
+        .arg(
             Arg::new("setup")
                 .long("setup")
                 .short('s')

--- a/src/export/markup.rs
+++ b/src/export/markup.rs
@@ -52,7 +52,7 @@ pub trait MarkupExporter {
             let min_str = format_duration_value(measurement.min, Some(unit)).0;
             let max_str = format_duration_value(measurement.max, Some(unit)).0;
             let rel_str = format!("{:.2}", entry.relative_speed);
-            let rel_stddev_str = if entry.is_fastest {
+            let rel_stddev_str = if entry.is_reference {
                 "".into()
             } else if let Some(stddev) = entry.relative_speed_stddev {
                 format!(" ± {:.2}", stddev)
@@ -104,7 +104,7 @@ fn determine_unit_from_results(results: &[BenchmarkResult]) -> Unit {
 impl<T: MarkupExporter> Exporter for T {
     fn serialize(&self, results: &[BenchmarkResult], unit: Option<Unit>) -> Result<Vec<u8>> {
         let unit = unit.unwrap_or_else(|| determine_unit_from_results(results));
-        let entries = relative_speed::compute(results);
+        let entries = relative_speed::compute(relative_speed::fastest(results), results);
         if entries.is_none() {
             return Err(anyhow!(
                 "Relative speed comparison is not available for markup exporter."

--- a/src/options.rs
+++ b/src/options.rs
@@ -178,6 +178,9 @@ pub struct Options {
     /// Whether or not to ignore non-zero exit codes
     pub command_failure_action: CmdFailureAction,
 
+    /// Command to run before each *batch* of timing runs, i.e. before each individual benchmark
+    pub reference_command: Option<String>,
+
     /// Command(s) to run before each timing run
     pub preparation_command: Option<Vec<String>>,
 
@@ -207,6 +210,7 @@ impl Default for Options {
             warmup_count: 0,
             min_benchmarking_time: 3.0,
             command_failure_action: CmdFailureAction::RaiseError,
+            reference_command: None,
             preparation_command: None,
             setup_command: None,
             cleanup_command: None,
@@ -259,6 +263,8 @@ impl Options {
             }
             (None, None) => {}
         };
+
+        options.reference_command = matches.value_of("reference").map(String::from);
 
         options.setup_command = matches.value_of("setup").map(String::from);
 


### PR DESCRIPTION
As title enlists.

Closes #577.