### PR TITLE
Hyperfine no longer auto assumes /C for windows if cmd.exe is not the selected shell.

### DIFF
--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -130,7 +130,13 @@ impl<'a> Executor for ShellExecutor<'a> {
     ) -> Result<(TimingResult, ExitStatus)> {
         let mut command_builder = self.shell.command();
         command_builder
-            .arg(if cfg!(windows) { "/C" } else { "-c" })
+            .arg(
+                if cfg!(windows) && *self.shell == Shell::Default("cmd.exe") {
+                    "/C"
+                } else {
+                    "-c"
+                },
+            )
             .arg(command.get_command_line());
 
         let mut result = run_command_and_measure_common(

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,7 +20,7 @@ pub const DEFAULT_SHELL: &str = "sh";
 pub const DEFAULT_SHELL: &str = "cmd.exe";
 
 /// Shell to use for executing benchmarked commands
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Shell {
     /// Default shell command
     Default(&'static str),


### PR DESCRIPTION
Ensuring we only use cmd-specific command building when cmd is in use, as this prevents alternative shells to be run on windows, like Nushell.

Closes https://github.com/sharkdp/hyperfine/issues/568