### PR TITLE
Default to $TERM unset = colour on Win32

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -300,7 +300,7 @@ impl Options {
                     OutputStyleOption::Basic
                 } else if env::var_os("TERM")
                     .map(|t| t == "unknown" || t == "dumb")
-                    .unwrap_or(true)
+                    .unwrap_or(!cfg!(target_os = "windows"))
                     || env::var_os("NO_COLOR")
                         .map(|t| !t.is_empty())
                         .unwrap_or(false)


### PR DESCRIPTION
This otherwise respects all other configuration (NO_COLOR, TERM=dumb, &c.), but it's very common for the environment to be lacking TERM, which in that case usually means a pro-verbial TERM=cmd.exe, which is colour-capable

Reported in https://github.com/sharkdp/hyperfine/commit/049d1138c94b1654a80b3afc164bcc5c672560f5#commitcomment-86934718