### PR TITLE
refactor: Update to clap 4

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,7 +1,7 @@
 name: CICD
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.57.0"
+  MIN_SUPPORTED_RUST_VERSION: "1.60.0"
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
 on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "approx"
@@ -34,9 +34,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "d5c2ca00549910ec251e3bd15f87aeeb206c9456b9a77b43ff6c97c54042a472"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -104,35 +104,33 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "terminal_size 0.2.1",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "dfe581a2035db4174cdbdc91265e1aba50f381577f0510d0ad36c7bc59cc84a3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -159,13 +157,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size 0.1.17",
  "unicode-width",
  "winapi",
@@ -264,20 +262,14 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -317,16 +309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg 1.1.0",
- "hashbrown",
-]
-
-[[package]]
 name = "indicatif"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
 
 [[package]]
 name = "itertools"
@@ -369,9 +351,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "lazy_static"
@@ -381,9 +363,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "linux-raw-sys"
@@ -517,9 +499,9 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "pin-utils"
@@ -565,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -780,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.10"
+version = "0.35.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af895b90e5c071badc3136fc10ff0bcfc98747eadbaf43ed8f214e07ba8f8477"
+checksum = "985947f9b6423159c4726323f373be0a21bdb514c5af06a849cb3d2dce2d01e8"
 dependencies = [
  "bitflags",
  "errno",
@@ -800,18 +782,18 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -820,11 +802,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -853,9 +835,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -912,28 +894,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-dependencies = [
- "terminal_size 0.2.1",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -942,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ once_cell = "1.14"
 nix = { version = "0.25.0", features = ["zerocopy"] }
 
 [dependencies.clap]
-version = "3"
+version = "4.0.18"
 default-features = false
-features = ["suggestions", "color", "wrap_help", "cargo"]
+features = ["suggestions", "color", "wrap_help", "cargo", "help", "usage", "error-context"]
 
 [dev-dependencies]
 approx = "0.5"
@@ -53,9 +53,9 @@ predicates = "2.1"
 tempfile = "3.3"
 
 [build-dependencies]
-clap = "3"
+clap = "4.0.18"
 atty = "0.2"
-clap_complete = "3"
+clap_complete = "4.0.3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "hyperfine"
 readme = "README.md"
 repository = "https://github.com/sharkdp/hyperfine"
 version = "1.15.0"
+rust-version = "1.60.0"
 edition = "2018"
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Hyperfine can be installed from source via [cargo](https://doc.rust-lang.org/car
 cargo install hyperfine
 ```
 
-Make sure that you use Rust 1.57 or higher.
+Make sure that you use Rust 1.60 or higher.
 
 ### From binaries (Linux, macOS, Windows)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,8 +17,8 @@ fn build_command() -> Command {
         .version(crate_version!())
         .next_line_help(true)
         .hide_possible_values(true)
-        .max_term_width(90)
         .about("A command-line benchmarking tool.")
+        .help_expected(true)
         .arg(
             Arg::new("command")
                 .help("The command to benchmark. This can be the name of an executable, a command \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 
-use clap::{crate_version, AppSettings, Arg, ArgMatches, Command};
+use clap::{crate_version, AppSettings, Arg, ArgMatches, Command, builder::NonEmptyStringValueParser, ArgAction};
 
 pub fn get_cli_arguments<'a, I, T>(args: I) -> ArgMatches
 where
@@ -28,8 +28,9 @@ fn build_command() -> Command<'static> {
                        '--shell=none'. If multiple commands are given, hyperfine will show a \
                        comparison of the respective runtimes.")
                 .required(true)
+                .action(ArgAction::StoreValue)
                 .multiple_occurrences(true)
-                .forbid_empty_values(true),
+                .value_parser(NonEmptyStringValueParser::new()),
         )
         .arg(
             Arg::new("warmup")
@@ -37,6 +38,7 @@ fn build_command() -> Command<'static> {
                 .short('w')
                 .takes_value(true)
                 .value_name("NUM")
+                .action(ArgAction::StoreValue)
                 .help(
                     "Perform NUM warmup runs before the actual benchmark. This can be used \
                      to fill (disk) caches for I/O-heavy programs.",
@@ -47,6 +49,7 @@ fn build_command() -> Command<'static> {
                 .long("min-runs")
                 .short('m')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("NUM")
                 .help("Perform at least NUM runs for each command (default: 10)."),
         )
@@ -55,6 +58,7 @@ fn build_command() -> Command<'static> {
                 .long("max-runs")
                 .short('M')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("NUM")
                 .help("Perform at most NUM runs for each command. By default, there is no limit."),
         )
@@ -64,6 +68,7 @@ fn build_command() -> Command<'static> {
                 .conflicts_with_all(&["max-runs", "min-runs"])
                 .short('r')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("NUM")
                 .help("Perform exactly NUM runs for each command. If this option is not specified, \
                        hyperfine automatically determines the number of runs."),
@@ -73,6 +78,7 @@ fn build_command() -> Command<'static> {
                 .long("setup")
                 .short('s')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .number_of_values(1)
                 .value_name("CMD")
                 .help(
@@ -87,6 +93,7 @@ fn build_command() -> Command<'static> {
                 .long("prepare")
                 .short('p')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .multiple_occurrences(true)
                 .number_of_values(1)
                 .value_name("CMD")
@@ -102,6 +109,7 @@ fn build_command() -> Command<'static> {
             Arg::new("cleanup")
                 .long("cleanup")
                 .short('c')
+                .action(ArgAction::StoreValue)
                 .takes_value(true)
                 .value_name("CMD")
                 .help(
@@ -116,6 +124,7 @@ fn build_command() -> Command<'static> {
                 .long("parameter-scan")
                 .short('P')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .allow_hyphen_values(true)
                 .value_names(&["VAR", "MIN", "MAX"])
                 .help(
@@ -134,6 +143,7 @@ fn build_command() -> Command<'static> {
                 .long("parameter-step-size")
                 .short('D')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_names(&["DELTA"])
                 .requires("parameter-scan")
                 .help(
@@ -148,6 +158,7 @@ fn build_command() -> Command<'static> {
                 .long("parameter-list")
                 .short('L')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .multiple_occurrences(true)
                 .allow_hyphen_values(true)
                 .value_names(&["VAR", "VALUES"])
@@ -165,8 +176,9 @@ fn build_command() -> Command<'static> {
             Arg::new("style")
                 .long("style")
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("TYPE")
-                .possible_values(&["auto", "basic", "full", "nocolor", "color", "none"])
+                .value_parser(["auto", "basic", "full", "nocolor", "color", "none"])
                 .help(
                     "Set output style type (default: auto). Set this to 'basic' to disable output \
                      coloring and interactive elements. Set it to 'full' to enable all effects \
@@ -181,6 +193,7 @@ fn build_command() -> Command<'static> {
                 .long("shell")
                 .short('S')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("SHELL")
                 .overrides_with("shell")
                 .help("Set the shell to use for executing benchmarked commands. This can be the \
@@ -194,12 +207,14 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("no-shell")
                 .short('N')
+                .action(ArgAction::IncOccurrence)
                 .conflicts_with_all(&["shell", "debug-mode"])
                 .help("An alias for '--shell=none'.")
         )
         .arg(
             Arg::new("ignore-failure")
                 .long("ignore-failure")
+                .action(ArgAction::IncOccurrence)
                 .short('i')
                 .help("Ignore non-zero exit codes of the benchmarked programs."),
         )
@@ -207,9 +222,10 @@ fn build_command() -> Command<'static> {
             Arg::new("time-unit")
                 .long("time-unit")
                 .short('u')
+                .action(ArgAction::StoreValue)
                 .takes_value(true)
                 .value_name("UNIT")
-                .possible_values(&["millisecond", "second"])
+                .value_parser(["millisecond", "second"])
                 .help("Set the time unit to be used. Possible values: millisecond, second. \
                        If the option is not given, the time unit is determined automatically. \
                        This option affects the standard output as well as all export formats except for CSV and JSON."),
@@ -217,6 +233,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-asciidoc")
                 .long("export-asciidoc")
+                .action(ArgAction::StoreValue)
                 .takes_value(true)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as an AsciiDoc table to the given FILE. \
@@ -225,6 +242,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-csv")
                 .long("export-csv")
+                .action(ArgAction::StoreValue)
                 .takes_value(true)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as CSV to the given FILE. If you need \
@@ -234,7 +252,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-json")
                 .long("export-json")
-                .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("FILE")
                 .help("Export the timing summary statistics and timings of individual runs as JSON to the given FILE. \
                        The output time unit is always seconds"),
@@ -243,6 +261,7 @@ fn build_command() -> Command<'static> {
             Arg::new("export-markdown")
                 .long("export-markdown")
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as a Markdown table to the given FILE. \
                        The output time unit can be changed using the --time-unit option."),
@@ -251,6 +270,7 @@ fn build_command() -> Command<'static> {
             Arg::new("export-orgmode")
                 .long("export-orgmode")
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as a Emacs org-mode table to the given FILE. \
                        The output time unit can be changed using the --time-unit option."),
@@ -258,6 +278,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("show-output")
                 .long("show-output")
+                .action(ArgAction::SetTrue)
                 .conflicts_with("style")
                 .help(
                     "Print the stdout and stderr of the benchmark instead of suppressing it. \
@@ -271,6 +292,7 @@ fn build_command() -> Command<'static> {
                 .long("output")
                 .conflicts_with("show-output")
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .value_name("WHERE")
                 .help(
                     "Control where the output of the benchmark is redirected. <WHERE> can be:\n\n\
@@ -288,6 +310,7 @@ fn build_command() -> Command<'static> {
                 .long("command-name")
                 .short('n')
                 .takes_value(true)
+                .action(ArgAction::StoreValue)
                 .multiple_occurrences(true)
                 .number_of_values(1)
                 .value_name("NAME")
@@ -300,6 +323,7 @@ fn build_command() -> Command<'static> {
             Arg::new("min-benchmarking-time")
             .long("min-benchmarking-time")
             .takes_value(true)
+            .action(ArgAction::StoreValue)
             .hide(true)
             .help("Set the minimum time (in seconds) to run benchmarks. Note that the number of \
                    benchmark runs is additionally influenced by the `--min-runs`, `--max-runs`, and \
@@ -308,6 +332,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("debug-mode")
             .long("debug-mode")
+            .action(ArgAction::IncOccurrence)
             .hide(true)
             .help("Enable debug mode which does not actually run commands, but returns fake times when the command is 'sleep <time>'.")
         )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use std::ffi::OsString;
 
-use clap::{crate_version, Arg, ArgMatches, Command, builder::NonEmptyStringValueParser, ArgAction};
+use clap::{
+    builder::NonEmptyStringValueParser, crate_version, Arg, ArgAction, ArgMatches, Command,
+};
 
 pub fn get_cli_arguments<'a, I, T>(args: I) -> ArgMatches
 where

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 
-use clap::{crate_version, AppSettings, Arg, ArgMatches, Command, builder::NonEmptyStringValueParser, ArgAction};
+use clap::{crate_version, Arg, ArgMatches, Command, builder::NonEmptyStringValueParser, ArgAction};
 
 pub fn get_cli_arguments<'a, I, T>(args: I) -> ArgMatches
 where
@@ -12,10 +12,9 @@ where
 }
 
 /// Build the clap command for parsing command line arguments
-fn build_command() -> Command<'static> {
+fn build_command() -> Command {
     Command::new("hyperfine")
         .version(crate_version!())
-        .setting(AppSettings::DeriveDisplayOrder)
         .next_line_help(true)
         .hide_possible_values(true)
         .max_term_width(90)
@@ -28,8 +27,7 @@ fn build_command() -> Command<'static> {
                        '--shell=none'. If multiple commands are given, hyperfine will show a \
                        comparison of the respective runtimes.")
                 .required(true)
-                .action(ArgAction::StoreValue)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .value_parser(NonEmptyStringValueParser::new()),
         )
         .arg(
@@ -87,7 +85,7 @@ fn build_command() -> Command<'static> {
                 .long("prepare")
                 .short('p')
                 .action(ArgAction::Append)
-                .number_of_values(1)
+                .num_args(1)
                 .value_name("CMD")
                 .help(
                     "Execute CMD before each timing run. This is useful for \
@@ -289,7 +287,7 @@ fn build_command() -> Command<'static> {
                 .long("command-name")
                 .short('n')
                 .action(ArgAction::Append)
-                .number_of_values(1)
+                .num_args(1)
                 .value_name("NAME")
                 .help("Give a meaningful name to a command. This can be specified multiple times \
                        if several commands are benchmarked."),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,9 +36,8 @@ fn build_command() -> Command<'static> {
             Arg::new("warmup")
                 .long("warmup")
                 .short('w')
-                .takes_value(true)
                 .value_name("NUM")
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .help(
                     "Perform NUM warmup runs before the actual benchmark. This can be used \
                      to fill (disk) caches for I/O-heavy programs.",
@@ -48,8 +47,7 @@ fn build_command() -> Command<'static> {
             Arg::new("min-runs")
                 .long("min-runs")
                 .short('m')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("NUM")
                 .help("Perform at least NUM runs for each command (default: 10)."),
         )
@@ -57,8 +55,7 @@ fn build_command() -> Command<'static> {
             Arg::new("max-runs")
                 .long("max-runs")
                 .short('M')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("NUM")
                 .help("Perform at most NUM runs for each command. By default, there is no limit."),
         )
@@ -67,8 +64,7 @@ fn build_command() -> Command<'static> {
                 .long("runs")
                 .conflicts_with_all(&["max-runs", "min-runs"])
                 .short('r')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("NUM")
                 .help("Perform exactly NUM runs for each command. If this option is not specified, \
                        hyperfine automatically determines the number of runs."),
@@ -77,9 +73,7 @@ fn build_command() -> Command<'static> {
             Arg::new("setup")
                 .long("setup")
                 .short('s')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
-                .number_of_values(1)
+                .action(ArgAction::Set)
                 .value_name("CMD")
                 .help(
                     "Execute CMD before each set of timing runs. This is useful for \
@@ -92,9 +86,7 @@ fn build_command() -> Command<'static> {
             Arg::new("prepare")
                 .long("prepare")
                 .short('p')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1)
                 .value_name("CMD")
                 .help(
@@ -109,8 +101,7 @@ fn build_command() -> Command<'static> {
             Arg::new("cleanup")
                 .long("cleanup")
                 .short('c')
-                .action(ArgAction::StoreValue)
-                .takes_value(true)
+                .action(ArgAction::Set)
                 .value_name("CMD")
                 .help(
                     "Execute CMD after the completion of all benchmarking \
@@ -123,8 +114,7 @@ fn build_command() -> Command<'static> {
             Arg::new("parameter-scan")
                 .long("parameter-scan")
                 .short('P')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .allow_hyphen_values(true)
                 .value_names(&["VAR", "MIN", "MAX"])
                 .help(
@@ -142,8 +132,7 @@ fn build_command() -> Command<'static> {
             Arg::new("parameter-step-size")
                 .long("parameter-step-size")
                 .short('D')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_names(&["DELTA"])
                 .requires("parameter-scan")
                 .help(
@@ -157,9 +146,7 @@ fn build_command() -> Command<'static> {
             Arg::new("parameter-list")
                 .long("parameter-list")
                 .short('L')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .allow_hyphen_values(true)
                 .value_names(&["VAR", "VALUES"])
                 .conflicts_with_all(&["parameter-scan", "parameter-step-size"])
@@ -175,8 +162,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("style")
                 .long("style")
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("TYPE")
                 .value_parser(["auto", "basic", "full", "nocolor", "color", "none"])
                 .help(
@@ -192,8 +178,7 @@ fn build_command() -> Command<'static> {
             Arg::new("shell")
                 .long("shell")
                 .short('S')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("SHELL")
                 .overrides_with("shell")
                 .help("Set the shell to use for executing benchmarked commands. This can be the \
@@ -207,14 +192,14 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("no-shell")
                 .short('N')
-                .action(ArgAction::IncOccurrence)
+                .action(ArgAction::SetTrue)
                 .conflicts_with_all(&["shell", "debug-mode"])
                 .help("An alias for '--shell=none'.")
         )
         .arg(
             Arg::new("ignore-failure")
                 .long("ignore-failure")
-                .action(ArgAction::IncOccurrence)
+                .action(ArgAction::SetTrue)
                 .short('i')
                 .help("Ignore non-zero exit codes of the benchmarked programs."),
         )
@@ -222,8 +207,7 @@ fn build_command() -> Command<'static> {
             Arg::new("time-unit")
                 .long("time-unit")
                 .short('u')
-                .action(ArgAction::StoreValue)
-                .takes_value(true)
+                .action(ArgAction::Set)
                 .value_name("UNIT")
                 .value_parser(["millisecond", "second"])
                 .help("Set the time unit to be used. Possible values: millisecond, second. \
@@ -233,8 +217,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-asciidoc")
                 .long("export-asciidoc")
-                .action(ArgAction::StoreValue)
-                .takes_value(true)
+                .action(ArgAction::Set)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as an AsciiDoc table to the given FILE. \
                        The output time unit can be changed using the --time-unit option."),
@@ -242,8 +225,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-csv")
                 .long("export-csv")
-                .action(ArgAction::StoreValue)
-                .takes_value(true)
+                .action(ArgAction::Set)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as CSV to the given FILE. If you need \
                        the timing results for each individual run, use the JSON export format. \
@@ -252,7 +234,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-json")
                 .long("export-json")
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("FILE")
                 .help("Export the timing summary statistics and timings of individual runs as JSON to the given FILE. \
                        The output time unit is always seconds"),
@@ -260,8 +242,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-markdown")
                 .long("export-markdown")
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as a Markdown table to the given FILE. \
                        The output time unit can be changed using the --time-unit option."),
@@ -269,8 +250,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("export-orgmode")
                 .long("export-orgmode")
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("FILE")
                 .help("Export the timing summary statistics as a Emacs org-mode table to the given FILE. \
                        The output time unit can be changed using the --time-unit option."),
@@ -291,8 +271,7 @@ fn build_command() -> Command<'static> {
             Arg::new("output")
                 .long("output")
                 .conflicts_with("show-output")
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
+                .action(ArgAction::Set)
                 .value_name("WHERE")
                 .help(
                     "Control where the output of the benchmark is redirected. <WHERE> can be:\n\n\
@@ -309,9 +288,7 @@ fn build_command() -> Command<'static> {
             Arg::new("command-name")
                 .long("command-name")
                 .short('n')
-                .takes_value(true)
-                .action(ArgAction::StoreValue)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1)
                 .value_name("NAME")
                 .help("Give a meaningful name to a command. This can be specified multiple times \
@@ -322,8 +299,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("min-benchmarking-time")
             .long("min-benchmarking-time")
-            .takes_value(true)
-            .action(ArgAction::StoreValue)
+            .action(ArgAction::Set)
             .hide(true)
             .help("Set the minimum time (in seconds) to run benchmarks. Note that the number of \
                    benchmark runs is additionally influenced by the `--min-runs`, `--max-runs`, and \
@@ -332,7 +308,7 @@ fn build_command() -> Command<'static> {
         .arg(
             Arg::new("debug-mode")
             .long("debug-mode")
-            .action(ArgAction::IncOccurrence)
+            .action(ArgAction::SetTrue)
             .hide(true)
             .help("Enable debug mode which does not actually run commands, but returns fake times when the command is 'sleep <time>'.")
         )

--- a/src/command.rs
+++ b/src/command.rs
@@ -122,7 +122,7 @@ impl<'a> Commands<'a> {
         let command_strings = matches.values_of("command").unwrap();
 
         if let Some(args) = matches.values_of("parameter-scan") {
-            let step_size = matches.value_of("parameter-step-size");
+            let step_size = matches.get_one::<String>("parameter-step-size").map(|s| s.as_str());
             Ok(Self(Self::get_parameter_scan_commands(
                 command_names,
                 command_strings,

--- a/src/command.rs
+++ b/src/command.rs
@@ -221,9 +221,8 @@ impl<'a> Commands<'a> {
                 return Err(OptionsError::TooManyCommandNames(command_strings.len()).into());
             }
 
-            let command_list = command_strings;
-            let mut commands = Vec::with_capacity(command_list.len());
-            for (i, s) in command_list.iter().enumerate() {
+            let mut commands = Vec::with_capacity(command_strings.len());
+            for (i, s) in command_strings.iter().enumerate() {
                 commands.push(Command::new(command_names.get(i).copied(), s));
             }
             Ok(Self(commands))

--- a/src/command.rs
+++ b/src/command.rs
@@ -154,9 +154,8 @@ impl<'a> Commands<'a> {
                     bail!("Duplicate parameter names: {}", &duplicates.join(", "));
                 }
             }
-            let command_list = command_strings;
 
-            let dimensions: Vec<usize> = std::iter::once(command_list.len())
+            let dimensions: Vec<usize> = std::iter::once(command_strings.len())
                 .chain(
                     param_names_and_values
                         .iter()
@@ -197,7 +196,7 @@ impl<'a> Commands<'a> {
                     .collect();
                 commands.push(Command::new_parametrized(
                     name,
-                    command_list[*command_index],
+                    command_strings[*command_index],
                     parameters,
                 ));
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,13 +10,12 @@ use crate::{
     },
 };
 
-use clap::ArgMatches;
+use clap::{ArgMatches, parser::ValuesRef};
 
 use crate::parameter::tokenize::tokenize;
 use crate::parameter::ParameterValue;
 
 use anyhow::{bail, Context, Result};
-use clap::Values;
 use rust_decimal::Decimal;
 
 /// A command that should be benchmarked.
@@ -118,10 +117,10 @@ pub struct Commands<'a>(Vec<Command<'a>>);
 
 impl<'a> Commands<'a> {
     pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands> {
-        let command_names = matches.values_of("command-name");
-        let command_strings = matches.values_of("command").unwrap();
+        let command_names = matches.get_many::<String>("command-name");
+        let command_strings = matches.get_many::<String>("command").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>();
 
-        if let Some(args) = matches.values_of("parameter-scan") {
+        if let Some(args) = matches.get_many::<String>("parameter-scan") {
             let step_size = matches.get_one::<String>("parameter-step-size").map(|s| s.as_str());
             Ok(Self(Self::get_parameter_scan_commands(
                 command_names,
@@ -129,10 +128,9 @@ impl<'a> Commands<'a> {
                 args,
                 step_size,
             )?))
-        } else if let Some(args) = matches.values_of("parameter-list") {
-            let command_names = command_names.map_or(vec![], |names| names.collect::<Vec<&str>>());
-
-            let args: Vec<_> = args.collect();
+        } else if let Some(args) = matches.get_many::<String>("parameter-list") {
+            let command_names = command_names.map_or(vec![], |names| names.map(|v| v.as_str()).collect::<Vec<_>>());
+            let args: Vec<_> = args.map(|v| v.as_str()).collect::<Vec<_>>();
             let param_names_and_values: Vec<(&str, Vec<String>)> = args
                 .chunks_exact(2)
                 .map(|pair| {
@@ -148,7 +146,7 @@ impl<'a> Commands<'a> {
                     bail!("Duplicate parameter names: {}", &duplicates.join(", "));
                 }
             }
-            let command_list = command_strings.collect::<Vec<&str>>();
+            let command_list = command_strings;
 
             let dimensions: Vec<usize> = std::iter::once(command_list.len())
                 .chain(
@@ -209,12 +207,12 @@ impl<'a> Commands<'a> {
 
             Ok(Self(commands))
         } else {
-            let command_names = command_names.map_or(vec![], |names| names.collect::<Vec<&str>>());
+            let command_names = command_names.map_or(vec![], |names| names.map(|v| v.as_str()).collect::<Vec<_>>());
             if command_names.len() > command_strings.len() {
                 return Err(OptionsError::TooManyCommandNames(command_strings.len()).into());
             }
 
-            let command_list = command_strings.collect::<Vec<&str>>();
+            let command_list = command_strings;
             let mut commands = Vec::with_capacity(command_list.len());
             for (i, s) in command_list.iter().enumerate() {
                 commands.push(Command::new(command_names.get(i).copied(), s));
@@ -285,16 +283,16 @@ impl<'a> Commands<'a> {
     }
 
     fn get_parameter_scan_commands<'b>(
-        command_names: Option<Values<'b>>,
-        command_strings: Values<'b>,
-        mut vals: clap::Values<'b>,
+        command_names: Option<ValuesRef<'b, String>>,
+        command_strings: Vec<&'b str>,
+        mut vals: ValuesRef<'b, String>,
         step: Option<&str>,
     ) -> Result<Vec<Command<'b>>, ParameterScanError> {
-        let command_names = command_names.map_or(vec![], |names| names.collect::<Vec<&str>>());
-        let command_strings = command_strings.collect::<Vec<&str>>();
-        let param_name = vals.next().unwrap();
-        let param_min = vals.next().unwrap();
-        let param_max = vals.next().unwrap();
+        let command_names = command_names.map_or(vec![], |names| names.map(|v| v.as_str()).collect::<Vec<_>>());
+        let command_strings = command_strings;
+        let param_name = vals.next().unwrap().as_str();
+        let param_min = vals.next().unwrap().as_str();
+        let param_max = vals.next().unwrap().as_str();
 
         // attempt to parse as integers
         if let (Ok(param_min), Ok(param_max), Ok(step)) = (

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 
-use clap::{ArgMatches, parser::ValuesRef};
+use clap::{parser::ValuesRef, ArgMatches};
 
 use crate::parameter::tokenize::tokenize;
 use crate::parameter::ParameterValue;
@@ -118,10 +118,16 @@ pub struct Commands<'a>(Vec<Command<'a>>);
 impl<'a> Commands<'a> {
     pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands> {
         let command_names = matches.get_many::<String>("command-name");
-        let command_strings = matches.get_many::<String>("command").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>();
+        let command_strings = matches
+            .get_many::<String>("command")
+            .unwrap_or_default()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>();
 
         if let Some(args) = matches.get_many::<String>("parameter-scan") {
-            let step_size = matches.get_one::<String>("parameter-step-size").map(|s| s.as_str());
+            let step_size = matches
+                .get_one::<String>("parameter-step-size")
+                .map(|s| s.as_str());
             Ok(Self(Self::get_parameter_scan_commands(
                 command_names,
                 command_strings,
@@ -129,7 +135,9 @@ impl<'a> Commands<'a> {
                 step_size,
             )?))
         } else if let Some(args) = matches.get_many::<String>("parameter-list") {
-            let command_names = command_names.map_or(vec![], |names| names.map(|v| v.as_str()).collect::<Vec<_>>());
+            let command_names = command_names.map_or(vec![], |names| {
+                names.map(|v| v.as_str()).collect::<Vec<_>>()
+            });
             let args: Vec<_> = args.map(|v| v.as_str()).collect::<Vec<_>>();
             let param_names_and_values: Vec<(&str, Vec<String>)> = args
                 .chunks_exact(2)
@@ -207,7 +215,9 @@ impl<'a> Commands<'a> {
 
             Ok(Self(commands))
         } else {
-            let command_names = command_names.map_or(vec![], |names| names.map(|v| v.as_str()).collect::<Vec<_>>());
+            let command_names = command_names.map_or(vec![], |names| {
+                names.map(|v| v.as_str()).collect::<Vec<_>>()
+            });
             if command_names.len() > command_strings.len() {
                 return Err(OptionsError::TooManyCommandNames(command_strings.len()).into());
             }
@@ -288,7 +298,9 @@ impl<'a> Commands<'a> {
         mut vals: ValuesRef<'b, String>,
         step: Option<&str>,
     ) -> Result<Vec<Command<'b>>, ParameterScanError> {
-        let command_names = command_names.map_or(vec![], |names| names.map(|v| v.as_str()).collect::<Vec<_>>());
+        let command_names = command_names.map_or(vec![], |names| {
+            names.map(|v| v.as_str()).collect::<Vec<_>>()
+        });
         let command_strings = command_strings;
         let param_name = vals.next().unwrap().as_str();
         let param_min = vals.next().unwrap().as_str();

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -63,7 +63,7 @@ impl ExportManager {
         let mut export_manager = Self::default();
         {
             let mut add_exporter = |flag, exporttype| -> Result<()> {
-                if let Some(filename) = matches.value_of(flag) {
+                if let Some(filename) = matches.get_one::<String>(flag) {
                     export_manager.add_exporter(exporttype, filename)?;
                 }
                 Ok(())

--- a/src/options.rs
+++ b/src/options.rs
@@ -325,7 +325,10 @@ impl Options {
         options.executor_kind = if matches.get_flag("no-shell") {
             ExecutorKind::Raw
         } else {
-            match (matches.get_flag("debug-mode"), matches.get_one::<String>("shell")) {
+            match (
+                matches.get_flag("debug-mode"),
+                matches.get_one::<String>("shell"),
+            ) {
                 (false, Some(shell)) if shell == "default" => ExecutorKind::Shell(Shell::default()),
                 (false, Some(shell)) if shell == "none" => ExecutorKind::Raw,
                 (false, Some(shell)) => ExecutorKind::Shell(Shell::parse_from_str(shell)?),

--- a/src/options.rs
+++ b/src/options.rs
@@ -223,7 +223,7 @@ impl Options {
         let mut options = Self::default();
         let param_to_u64 = |param| {
             matches
-                .value_of(param)
+                .get_one::<String>(param)
                 .map(|n| {
                     n.parse::<u64>()
                         .map_err(|e| OptionsError::IntParsingError(param, e))
@@ -260,17 +260,17 @@ impl Options {
             (None, None) => {}
         };
 
-        options.setup_command = matches.value_of("setup").map(String::from);
+        options.setup_command = matches.get_one::<String>("setup").map(String::from);
 
         options.preparation_command = matches
-            .values_of("prepare")
+            .get_many::<String>("prepare")
             .map(|values| values.map(String::from).collect::<Vec<String>>());
 
-        options.cleanup_command = matches.value_of("cleanup").map(String::from);
+        options.cleanup_command = matches.get_one::<String>("cleanup").map(String::from);
 
-        options.command_output_policy = if matches.is_present("show-output") {
+        options.command_output_policy = if matches.contains_id("show-output") {
             CommandOutputPolicy::Inherit
-        } else if let Some(output) = matches.value_of("output") {
+        } else if let Some(output) = matches.get_one::<String>("output").map(|s| s.as_str()) {
             match output {
                 "null" => CommandOutputPolicy::Null,
                 "pipe" => CommandOutputPolicy::Pipe,
@@ -287,7 +287,7 @@ impl Options {
             CommandOutputPolicy::Null
         };
 
-        options.output_style = match matches.value_of("style") {
+        options.output_style = match matches.get_one::<String>("style").map(|s| s.as_str()) {
             Some("full") => OutputStyleOption::Full,
             Some("basic") => OutputStyleOption::Basic,
             Some("nocolor") => OutputStyleOption::NoColor,
@@ -322,10 +322,10 @@ impl Options {
             OutputStyleOption::Disabled => {}
         };
 
-        options.executor_kind = if matches.is_present("no-shell") {
+        options.executor_kind = if matches.contains_id("no-shell") {
             ExecutorKind::Raw
         } else {
-            match (matches.is_present("debug-mode"), matches.value_of("shell")) {
+            match (matches.contains_id("debug-mode"), matches.get_one::<String>("shell")) {
                 (false, Some(shell)) if shell == "default" => ExecutorKind::Shell(Shell::default()),
                 (false, Some(shell)) if shell == "none" => ExecutorKind::Raw,
                 (false, Some(shell)) => ExecutorKind::Shell(Shell::parse_from_str(shell)?),
@@ -335,17 +335,17 @@ impl Options {
             }
         };
 
-        if matches.is_present("ignore-failure") {
+        if matches.contains_id("ignore-failure") {
             options.command_failure_action = CmdFailureAction::Ignore;
         }
 
-        options.time_unit = match matches.value_of("time-unit") {
+        options.time_unit = match matches.get_one::<String>("time-unit").map(|s| s.as_str()) {
             Some("millisecond") => Some(Unit::MilliSecond),
             Some("second") => Some(Unit::Second),
             _ => None,
         };
 
-        if let Some(time) = matches.value_of("min-benchmarking-time") {
+        if let Some(time) = matches.get_one::<String>("min-benchmarking-time") {
             options.min_benchmarking_time = time
                 .parse::<f64>()
                 .map_err(|e| OptionsError::FloatParsingError("min-benchmarking-time", e))?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -268,7 +268,7 @@ impl Options {
 
         options.cleanup_command = matches.get_one::<String>("cleanup").map(String::from);
 
-        options.command_output_policy = if matches.contains_id("show-output") {
+        options.command_output_policy = if matches.get_flag("show-output") {
             CommandOutputPolicy::Inherit
         } else if let Some(output) = matches.get_one::<String>("output").map(|s| s.as_str()) {
             match output {
@@ -322,10 +322,10 @@ impl Options {
             OutputStyleOption::Disabled => {}
         };
 
-        options.executor_kind = if matches.contains_id("no-shell") {
+        options.executor_kind = if matches.get_flag("no-shell") {
             ExecutorKind::Raw
         } else {
-            match (matches.contains_id("debug-mode"), matches.get_one::<String>("shell")) {
+            match (matches.get_flag("debug-mode"), matches.get_one::<String>("shell")) {
                 (false, Some(shell)) if shell == "default" => ExecutorKind::Shell(Shell::default()),
                 (false, Some(shell)) if shell == "none" => ExecutorKind::Raw,
                 (false, Some(shell)) => ExecutorKind::Shell(Shell::parse_from_str(shell)?),
@@ -335,7 +335,7 @@ impl Options {
             }
         };
 
-        if matches.contains_id("ignore-failure") {
+        if matches.get_flag("ignore-failure") {
             options.command_failure_action = CmdFailureAction::Ignore;
         }
 


### PR DESCRIPTION
Closes #578 

- Followed the [migration guide](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating).
- Added features (help, usage, error-context) because of `default-features = false`.
- There could be some subtle breaking changes, but the existing tests were quite extensive.
- Removed `max_term_width(90)` in favor of wrap_help.
- The default new output of `--help` has some subtle changes, that all seem good, reducing the total output size from 161 lines to 133 lines (with equal width `COLUMNS=90`).
- The default template has changed things like color and capitalization. This is has been [discussed before with bat](https://github.com/sharkdp/bat/pull/2327).

TODO:
- There are some Builder patterns like usage strings e.g. `arg!` that could simplify things, but these are not used here.

clap v3 `hyperfine --help`
![image](https://user-images.githubusercontent.com/8041507/198551331-373d9f9d-02e3-45b5-881e-908c5185fa64.png)

clap v4 `cargo run -- hyperfine --help`
![image](https://user-images.githubusercontent.com/8041507/198551636-7dbf4431-8427-45d5-a3c6-7ce1882b6a87.png)
