### PR TITLE
Fix get_cmap MatplotlibDeprecationWarning

### DIFF
--- a/scripts/plot_whisker.py
+++ b/scripts/plot_whisker.py
@@ -34,7 +34,7 @@ else:
 times = [b["times"] for b in results]
 
 boxplot = plt.boxplot(times, vert=True, patch_artist=True)
-cmap = plt.colormaps["rainbow"]
+cmap = plt.get_cmap("rainbow")
 colors = [cmap(val / len(times)) for val in range(len(times))]
 
 for patch, color in zip(boxplot["boxes"], colors):

--- a/scripts/plot_whisker.py
+++ b/scripts/plot_whisker.py
@@ -34,7 +34,7 @@ else:
 times = [b["times"] for b in results]
 
 boxplot = plt.boxplot(times, vert=True, patch_artist=True)
-cmap = plt.cm.get_cmap("rainbow")
+cmap = plt.colormaps["rainbow"]
 colors = [cmap(val / len(times)) for val in range(len(times))]
 
 for patch, color in zip(boxplot["boxes"], colors):


### PR DESCRIPTION
```
[~] ~/hyperfine/scripts/plot_whisker.py -o result.jpg results.json
~/hyperfine/scripts/plot_whisker.py:37: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
  cmap = plt.cm.get_cmap("rainbow")
```

After this change, the warning disappears, and the output plot looks unchanged.