### PR TITLE
Add new --sort option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,21 +161,6 @@ fn build_command() -> Command {
                 ),
         )
         .arg(
-            Arg::new("style")
-                .long("style")
-                .action(ArgAction::Set)
-                .value_name("TYPE")
-                .value_parser(["auto", "basic", "full", "nocolor", "color", "none"])
-                .help(
-                    "Set output style type (default: auto). Set this to 'basic' to disable output \
-                     coloring and interactive elements. Set it to 'full' to enable all effects \
-                     even if no interactive terminal was detected. Set this to 'nocolor' to \
-                     keep the interactive output without any colors. Set this to 'color' to keep \
-                     the colors without any interactive output. Set this to 'none' to disable all \
-                     the output of the tool.",
-                ),
-        )
-        .arg(
             Arg::new("shell")
                 .long("shell")
                 .short('S')
@@ -203,6 +188,38 @@ fn build_command() -> Command {
                 .action(ArgAction::SetTrue)
                 .short('i')
                 .help("Ignore non-zero exit codes of the benchmarked programs."),
+        )
+        .arg(
+            Arg::new("style")
+                .long("style")
+                .action(ArgAction::Set)
+                .value_name("TYPE")
+                .value_parser(["auto", "basic", "full", "nocolor", "color", "none"])
+                .help(
+                    "Set output style type (default: auto). Set this to 'basic' to disable output \
+                     coloring and interactive elements. Set it to 'full' to enable all effects \
+                     even if no interactive terminal was detected. Set this to 'nocolor' to \
+                     keep the interactive output without any colors. Set this to 'color' to keep \
+                     the colors without any interactive output. Set this to 'none' to disable all \
+                     the output of the tool.",
+                ),
+        )
+        .arg(
+            Arg::new("sort")
+            .long("sort")
+            .action(ArgAction::Set)
+            .value_name("METHOD")
+            .value_parser(["auto", "command", "mean-time"])
+            .default_value("auto")
+            .hide_default_value(true)
+            .help(
+                "Specify the sort order of the speed comparison summary and the exported tables for \
+                 markup formats (Markdown, AsciiDoc, org-mode):\n  \
+                   * 'auto' (default): the speed comparison will be ordered by time and\n    \
+                     the markup tables will be ordered by command (input order).\n  \
+                   * 'command': order benchmarks in the way they were specified\n  \
+                   * 'mean-time': order benchmarks by mean runtime\n"
+            ),
         )
         .arg(
             Arg::new("time-unit")

--- a/src/export/asciidoc.rs
+++ b/src/export/asciidoc.rs
@@ -77,6 +77,9 @@ fn cfg_test_table_header(unit_short_name: &str) -> String {
 }
 
 #[cfg(test)]
+use crate::options::SortOrder;
+
+#[cfg(test)]
 use crate::util::units::Unit;
 
 #[cfg(test)]
@@ -132,8 +135,12 @@ fn test_asciidoc_format_s() {
         },
     ];
 
-    let actual =
-        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let actual = String::from_utf8(
+        exporter
+            .serialize(&results, Some(Unit::Second), SortOrder::Command)
+            .unwrap(),
+    )
+    .unwrap();
     let expect = format!(
         "{}
 | `FOO=1 BAR=2 command \\| 1` 
@@ -205,7 +212,7 @@ fn test_asciidoc_format_ms() {
 
     let actual = String::from_utf8(
         exporter
-            .serialize(&results, Some(Unit::MilliSecond))
+            .serialize(&results, Some(Unit::MilliSecond), SortOrder::Command)
             .unwrap(),
     )
     .unwrap();

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -4,6 +4,7 @@ use csv::WriterBuilder;
 
 use super::Exporter;
 use crate::benchmark::benchmark_result::BenchmarkResult;
+use crate::options::SortOrder;
 use crate::util::units::Unit;
 
 use anyhow::Result;
@@ -12,7 +13,12 @@ use anyhow::Result;
 pub struct CsvExporter {}
 
 impl Exporter for CsvExporter {
-    fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
+    fn serialize(
+        &self,
+        results: &[BenchmarkResult],
+        _unit: Option<Unit>,
+        _sort_order: SortOrder,
+    ) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
 
         {
@@ -105,8 +111,12 @@ fn test_csv() {
         FOO=one BAR=seven command | 2,11,12,11,13,14,15,16.5,seven,one\n\
         ",
     );
-    let gens =
-        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let gens = String::from_utf8(
+        exporter
+            .serialize(&results, Some(Unit::Second), SortOrder::Command)
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(exps, gens);
 }

--- a/src/export/json.rs
+++ b/src/export/json.rs
@@ -3,6 +3,7 @@ use serde_json::to_vec_pretty;
 
 use super::Exporter;
 use crate::benchmark::benchmark_result::BenchmarkResult;
+use crate::options::SortOrder;
 use crate::util::units::Unit;
 
 use anyhow::Result;
@@ -16,7 +17,12 @@ struct HyperfineSummary<'a> {
 pub struct JsonExporter {}
 
 impl Exporter for JsonExporter {
-    fn serialize(&self, results: &[BenchmarkResult], _unit: Option<Unit>) -> Result<Vec<u8>> {
+    fn serialize(
+        &self,
+        results: &[BenchmarkResult],
+        _unit: Option<Unit>,
+        _sort_order: SortOrder,
+    ) -> Result<Vec<u8>> {
         let mut output = to_vec_pretty(&HyperfineSummary { results });
         if let Ok(ref mut content) = output {
             content.push(b'\n');

--- a/src/export/markup.rs
+++ b/src/export/markup.rs
@@ -1,5 +1,6 @@
 use crate::benchmark::relative_speed::BenchmarkResultWithRelativeSpeed;
 use crate::benchmark::{benchmark_result::BenchmarkResult, relative_speed};
+use crate::options::SortOrder;
 use crate::output::format::format_duration_value;
 use crate::util::units::Unit;
 
@@ -105,9 +106,14 @@ fn determine_unit_from_results(results: &[BenchmarkResult]) -> Unit {
 }
 
 impl<T: MarkupExporter> Exporter for T {
-    fn serialize(&self, results: &[BenchmarkResult], unit: Option<Unit>) -> Result<Vec<u8>> {
+    fn serialize(
+        &self,
+        results: &[BenchmarkResult],
+        unit: Option<Unit>,
+        sort_order: SortOrder,
+    ) -> Result<Vec<u8>> {
         let unit = unit.unwrap_or_else(|| determine_unit_from_results(results));
-        let entries = relative_speed::compute(results);
+        let entries = relative_speed::compute(results, sort_order);
 
         let table = self.table_results(&entries, unit);
         Ok(table.as_bytes().to_vec())

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -15,6 +15,7 @@ use self::markdown::MarkdownExporter;
 use self::orgmode::OrgmodeExporter;
 
 use crate::benchmark::benchmark_result::BenchmarkResult;
+use crate::options::SortOrder;
 use crate::util::units::Unit;
 
 use anyhow::{Context, Result};
@@ -42,7 +43,12 @@ pub enum ExportType {
 /// Interface for different exporters.
 trait Exporter {
     /// Export the given entries in the serialized form.
-    fn serialize(&self, results: &[BenchmarkResult], unit: Option<Unit>) -> Result<Vec<u8>>;
+    fn serialize(
+        &self,
+        results: &[BenchmarkResult],
+        unit: Option<Unit>,
+        sort_order: SortOrder,
+    ) -> Result<Vec<u8>>;
 }
 
 pub enum ExportTarget {
@@ -116,9 +122,14 @@ impl ExportManager {
     /// results are written to all file targets (to always have them up to date, even
     /// if a benchmark fails). In the latter case, we only print to stdout targets (in
     /// order not to clutter the output of hyperfine with intermediate results).
-    pub fn write_results(&self, results: &[BenchmarkResult], intermediate: bool) -> Result<()> {
+    pub fn write_results(
+        &self,
+        results: &[BenchmarkResult],
+        sort_order: SortOrder,
+        intermediate: bool,
+    ) -> Result<()> {
         for e in &self.exporters {
-            let content = || e.exporter.serialize(results, self.time_unit);
+            let content = || e.exporter.serialize(results, self.time_unit, sort_order);
 
             match e.target {
                 ExportTarget::File(ref filename) => {

--- a/src/export/orgmode.rs
+++ b/src/export/orgmode.rs
@@ -22,6 +22,9 @@ impl MarkupExporter for OrgmodeExporter {
     }
 }
 
+#[cfg(test)]
+use crate::options::SortOrder;
+
 /// Check Emacs org-mode data row formatting
 #[test]
 fn test_orgmode_formatter_table_data() {
@@ -105,7 +108,12 @@ fn test_orgmode_format_ms() {
         },
     ];
 
-    let actual = String::from_utf8(exporter.serialize(&results, None).unwrap()).unwrap();
+    let actual = String::from_utf8(
+        exporter
+            .serialize(&results, None, SortOrder::Command)
+            .unwrap(),
+    )
+    .unwrap();
     let expect = format!(
         "{}\
 | =sleep 0.1=  |  105.7 ± 1.6 |  102.3 |  108.0 |  1.00 |
@@ -159,8 +167,12 @@ fn test_orgmode_format_s() {
         },
     ];
 
-    let actual =
-        String::from_utf8(exporter.serialize(&results, Some(Unit::Second)).unwrap()).unwrap();
+    let actual = String::from_utf8(
+        exporter
+            .serialize(&results, Some(Unit::Second), SortOrder::Command)
+            .unwrap(),
+    )
+    .unwrap();
     let expect = format!(
         "{}\
 | =sleep 2=  |  2.005 ± 0.002 |  2.002 |  2.008 |  18.97 ± 0.29 |

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -398,3 +398,28 @@ fn unused_parameters_are_shown_in_benchmark_name() {
                 .and(predicate::str::contains("echo test (branch = feature)")),
         );
 }
+
+#[test]
+fn speed_comparison_sort_order() {
+    for sort_order in ["auto", "mean-time"] {
+        hyperfine_debug()
+            .arg("sleep 2")
+            .arg("sleep 1")
+            .arg(format!("--sort={sort_order}"))
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "sleep 1 ran\n    2.00 ± 0.00 times faster than sleep 2",
+            ));
+    }
+
+    hyperfine_debug()
+        .arg("sleep 2")
+        .arg("sleep 1")
+        .arg("--sort=command")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "2.00 ±  0.00  sleep 2\n        1.00          sleep 1",
+        ));
+}


### PR DESCRIPTION
This adds a new `--sort` option to choose the way in which the results in the speed comparison and the markup exports are ordered.

Default behavior, `--sort auto` or `--sort mean-time`:
![image](https://github.com/sharkdp/hyperfine/assets/4209276/9c8040d5-d4db-4c37-9280-b6c27cdf4585)

With `--sort command`
![image](https://github.com/sharkdp/hyperfine/assets/4209276/06c3f978-da39-487a-989c-c3267bcafad2)

Markdown export with `--sort mean-time`:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `sleep 0.1` | 101.1 ± 0.5 | 100.6 | 103.1 | 1.00 |
| `sleep 0.2` | 200.9 ± 0.3 | 200.7 | 201.9 | 1.99 ± 0.01 |
| `sleep 0.3` | 301.0 ± 0.2 | 300.8 | 301.3 | 2.98 ± 0.01 |

closes #614
closes #601