### PR TITLE
Use only colors supported by conhost.exe

### DIFF
--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -306,7 +306,7 @@ impl<'a> Benchmark<'a> {
 
                 println!(
                     "  Range ({} … {}):   {:>8} … {:>8}    {}",
-                    "min".bright_yellow().bold(),
+                    "min".bright_green(),
                     "max".bright_red(),
                     min_str.bright_green(),
                     max_str.bright_red(),

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -231,7 +231,7 @@ impl<'a> Benchmark<'a> {
 
             let msg = {
                 let mean = format_duration(mean(&times_real), self.options.time_unit);
-                format!("Current estimate: {}", mean.to_string().green())
+                format!("Current estimate: {}", mean.to_string().yellow().bold())
             };
 
             if let Some(bar) = progress_bar.as_ref() {
@@ -285,31 +285,31 @@ impl<'a> Benchmark<'a> {
             if times_real.len() == 1 {
                 println!(
                     "  Time ({} ≡):        {:>8}  {:>8}     [User: {}, System: {}]",
-                    "abs".green().bold(),
-                    mean_str.green().bold(),
+                    "abs".yellow().bold(),
+                    mean_str.yellow().bold(),
                     "        ", // alignment
-                    user_str.blue(),
-                    system_str.blue()
+                    user_str.cyan(),
+                    system_str.cyan()
                 );
             } else {
                 let stddev_str = format_duration(t_stddev.unwrap(), Some(time_unit));
 
                 println!(
                     "  Time ({} ± {}):     {:>8} ± {:>8}    [User: {}, System: {}]",
-                    "mean".green().bold(),
-                    "σ".green(),
-                    mean_str.green().bold(),
-                    stddev_str.green(),
-                    user_str.blue(),
-                    system_str.blue()
+                    "mean".yellow().bold(),
+                    "σ",
+                    mean_str.yellow().bold(),
+                    stddev_str,
+                    user_str.cyan(),
+                    system_str.cyan()
                 );
 
                 println!(
                     "  Range ({} … {}):   {:>8} … {:>8}    {}",
-                    "min".cyan(),
-                    "max".purple(),
-                    min_str.cyan(),
-                    max_str.purple(),
+                    "min".bright_yellow().bold(),
+                    "max".bright_red(),
+                    min_str.bright_green(),
+                    max_str.bright_red(),
                     num_str.dimmed()
                 );
             }
@@ -357,7 +357,7 @@ impl<'a> Benchmark<'a> {
             eprintln!(" ");
 
             for warning in &warnings {
-                eprintln!("  {}: {}", "Warning".yellow(), warning);
+                eprintln!("  {}: {}", "Warning".yellow().bold(), warning);
             }
         }
 

--- a/src/benchmark/scheduler.rs
+++ b/src/benchmark/scheduler.rs
@@ -84,13 +84,13 @@ impl<'a> Scheduler<'a> {
                     for item in others {
                         println!(
                             "{}{} times faster than {}",
-                            format!("{:8.2}", item.relative_speed).bold().green(),
+                            format!("{:8.2}", item.relative_speed).yellow().bold(),
                             if let Some(stddev) = item.relative_speed_stddev {
-                                format!(" ± {}", format!("{:.2}", stddev).green())
+                                format!(" ± {}", format!("{:.2}", stddev).yellow().bold())
                             } else {
                                 "".into()
                             },
-                            &item.result.command_with_unused_parameters.magenta()
+                            &item.result.command_with_unused_parameters.cyan()
                         );
                     }
                 }
@@ -100,11 +100,11 @@ impl<'a> Scheduler<'a> {
                     for item in annotated_results {
                         println!(
                             "  {}{}  {}",
-                            format!("{:10.2}", item.relative_speed).bold().green(),
+                            format!("{:10.2}", item.relative_speed).yellow().bold(),
                             if item.is_fastest {
                                 "        ".into()
                             } else if let Some(stddev) = item.relative_speed_stddev {
-                                format!(" ± {}", format!("{:5.2}", stddev).green())
+                                format!(" ± {}", format!("{:5.2}", stddev).yellow().bold())
                             } else {
                                 "        ".into()
                             },
@@ -121,7 +121,7 @@ impl<'a> Scheduler<'a> {
                  Try to re-run the benchmark on a quiet system. If you did not do so already, try the \
                  --shell=none/-N option. If it does not help either, you command is most likely too fast \
                  to be accurately benchmarked by hyperfine.",
-                 "Note".bold().red()
+                 "Note".bright_red()
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
     match run() {
         Ok(_) => {}
         Err(e) => {
-            eprintln!("{} {:#}", "Error:".red(), e);
+            eprintln!("{} {:#}", "Error:".bright_red(), e);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
The previous terminal for Windows is `conhost.exe` (the one with blue background) which renders some colors differently. 
Green and Red, for example, are quite dim, whereas, on typical unix terminal and modern Windows Terminal, they're indistinguishable from "normal" ones.

This patch changes the overall `hyperfine` color scheme to a few "safe" colors in the following manner.

<details><summary>Color scheme</summary>
<p>

#### Main measurement text:
    green -> yellow bold
    green bold -> yellow bold

#### Min:
    cyan -> bright green

#### Max:
    purple -> bright red

#### Other:
    blue -> cyan
    magenta -> cyan

</p>
</details> 

## Before:

<details><summary>conhost.exe</summary>
<p>

![image](https://github.com/sharkdp/hyperfine/assets/4996834/2c4eb492-59ed-4b9a-8b0d-db953cc06084)
![image](https://github.com/sharkdp/hyperfine/assets/4996834/098b58db-5733-4e7a-9c2b-f1d83b39bce4)

</p>
</details> 

<details><summary>Windows Terminal</summary>
<p>

![image](https://github.com/sharkdp/hyperfine/assets/4996834/e564d0ee-fe69-4778-8dbb-f7a9e6915edc)

</p>
</details> 

<details><summary>VS Code</summary>
<p>

![image](https://github.com/sharkdp/hyperfine/assets/4996834/57aae628-d320-41ed-ae68-f0ff53c00df2)

</p>
</details> 

## After:

<details><summary>conhost.exe</summary>
<p>

![image](https://github.com/sharkdp/hyperfine/assets/4996834/36e546fc-b7a2-43e6-8572-442cc0159712)
![image](https://github.com/sharkdp/hyperfine/assets/4996834/72cb97ee-2919-498d-8081-c3e8b3c78b9e)

</p>
</details> 

<details><summary>Windows Terminal</summary>
<p>

![image](https://github.com/sharkdp/hyperfine/assets/4996834/69fa2c25-6d73-46c7-9721-2fbc8572ca3f)

</p>
</details> 

<details><summary>VS Code</summary>
<p>

![image](https://github.com/sharkdp/hyperfine/assets/4996834/e7552a78-8c36-49ea-a498-8c16b13ffd8d)

</p>
</details> 

This PR addresses https://github.com/sharkdp/hyperfine/issues/507
