### PR TITLE
Change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -336,7 +336,7 @@ jobs:
 
   winget:
     name: Publish to Winget
-    runs-on: windows-latest # Action can only run on Windows
+    runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     steps:


### PR DESCRIPTION
See https://github.com/sharkdp/fd/pull/1364:
> Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.