### PR TITLE
Add short flag counterparts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,6 +192,7 @@ fn build_command() -> Command {
         .arg(
             Arg::new("style")
                 .long("style")
+                .short('l')
                 .action(ArgAction::Set)
                 .value_name("TYPE")
                 .value_parser(["auto", "basic", "full", "nocolor", "color", "none"])
@@ -207,6 +208,7 @@ fn build_command() -> Command {
         .arg(
             Arg::new("sort")
             .long("sort")
+            .short('t')
             .action(ArgAction::Set)
             .value_name("METHOD")
             .value_parser(["auto", "command", "mean-time"])
@@ -276,6 +278,7 @@ fn build_command() -> Command {
         .arg(
             Arg::new("show-output")
                 .long("show-output")
+                .short('d')
                 .action(ArgAction::SetTrue)
                 .conflicts_with("style")
                 .help(
@@ -288,6 +291,7 @@ fn build_command() -> Command {
         .arg(
             Arg::new("output")
                 .long("output")
+                .short('O')
                 .conflicts_with("show-output")
                 .action(ArgAction::Set)
                 .value_name("WHERE")
@@ -311,6 +315,7 @@ fn build_command() -> Command {
         .arg(
             Arg::new("input")
                 .long("input")
+                .short('I')
                 .action(ArgAction::Set)
                 .num_args(1)
                 .value_name("WHERE")


### PR DESCRIPTION
Short flags for `--style`, `--sort`, `--show-output`, `--output`, `--input`.

###### Adjust as needed for what's best to the project.

Closes #689