### PR TITLE
Remove dependency on `atty` and use `std::io::IsTerminal` instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,17 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,15 +455,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -486,7 +466,6 @@ dependencies = [
  "anyhow",
  "approx",
  "assert_cmd",
- "atty",
  "clap",
  "clap_complete",
  "colored",
@@ -535,7 +514,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ windows_process_extensions_main_thread_handle = []
 colored = "2.0"
 indicatif = "=0.17.4"
 statistical = "1.0"
-atty = "0.2"
 csv = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -61,7 +60,6 @@ tempfile = "3.3"
 
 [build-dependencies]
 clap = "4.0.18"
-atty = "0.2"
 clap_complete = "4.2.1"
 
 [profile.release]

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,10 +1,10 @@
 use std::fs::File;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::{cmp, env, fmt, io};
 
 use anyhow::ensure;
-use atty::Stream;
 use clap::ArgMatches;
 
 use crate::command::Commands;
@@ -333,7 +333,7 @@ impl Options {
             Some("none") => OutputStyleOption::Disabled,
             _ => {
                 if options.command_output_policy == CommandOutputPolicy::Inherit
-                    || !atty::is(Stream::Stdout)
+                    || !io::stdout().is_terminal()
                 {
                     OutputStyleOption::Basic
                 } else if env::var_os("TERM")


### PR DESCRIPTION
Since the [MSRV](https://github.com/sharkdp/hyperfine/commit/d91c126a9be8ea8d96c219d44ac8f458e402ffa1) is now 1.70, the implementation from `std` can be used instead.