### PR TITLE
Add openSUSE installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ On NixOS, hyperfine can be installed [from the official repositories](https://ni
 nix-env -i hyperfine
 ```
 
+### On openSUSE
+
+On openSUSE, hyperfine can be installed [from the official repositories](https://software.opensuse.org/package/hyperfine):
+```
+zypper install hyperfine
+```
+
 ### On Void Linux
 
 Hyperfine can be installed via xbps


### PR DESCRIPTION
hyperfine is available in the official repositories for the Tumbleweed and Leap 15.3 or later.[^1]

[^1]: <https://repology.org/project/hyperfine/versions>