### PR TITLE
fix: add a space in the progress bar template

### DIFF
--- a/src/output/progress_bar.rs
+++ b/src/output/progress_bar.rs
@@ -15,7 +15,7 @@ pub fn get_progress_bar(length: u64, msg: &str, option: OutputStyleOption) -> Pr
         OutputStyleOption::Basic | OutputStyleOption::Color => ProgressStyle::default_bar(),
         _ => ProgressStyle::default_spinner()
             .tick_chars(TICK_SETTINGS.0)
-            .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise}")
+            .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise} ")
             .expect("no template error"),
     };
 


### PR DESCRIPTION
![YcgdpIO](https://github.com/sharkdp/hyperfine/assets/92276115/617730ba-dbcc-47af-85a8-a141620c2056)
