### PR TITLE
Add `-E` and `--show-elapsed` flag to show the elapsed time.

### DIFF
--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -215,7 +215,8 @@ impl<'a> Executor for ShellExecutor<'a> {
             }
 
             if let Some(bar) = progress_bar.as_ref() {
-                bar.inc(1)
+                bar.inc(1);
+                bar.reset_elapsed();
             }
         }
 

--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -180,6 +180,7 @@ impl<'a> Executor for ShellExecutor<'a> {
                 COUNT,
                 "Measuring shell spawning time",
                 self.options.output_style,
+                self.options.show_elapsed,
             ))
         } else {
             None

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -165,7 +165,8 @@ impl<'a> Benchmark<'a> {
                 let _ = run_preparation_command()?;
                 let _ = self.executor.run_command_and_measure(self.command, None)?;
                 if let Some(bar) = progress_bar.as_ref() {
-                    bar.inc(1)
+                    bar.inc(1);
+                    bar.reset_elapsed();
                 }
             }
             if let Some(bar) = progress_bar.as_ref() {
@@ -224,7 +225,8 @@ impl<'a> Benchmark<'a> {
             bar.set_length(count)
         }
         if let Some(bar) = progress_bar.as_ref() {
-            bar.inc(1)
+            bar.inc(1);
+            bar.reset_elapsed();
         }
 
         // Gather statistics (perform the actual benchmark)
@@ -251,7 +253,8 @@ impl<'a> Benchmark<'a> {
             all_succeeded = all_succeeded && success;
 
             if let Some(bar) = progress_bar.as_ref() {
-                bar.inc(1)
+                bar.inc(1);
+                bar.reset_elapsed();
             }
         }
 

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -155,6 +155,7 @@ impl<'a> Benchmark<'a> {
                     self.options.warmup_count,
                     "Performing warmup runs",
                     self.options.output_style,
+                    self.options.show_elapsed,
                 ))
             } else {
                 None
@@ -178,6 +179,7 @@ impl<'a> Benchmark<'a> {
                 self.options.run_bounds.min,
                 "Initial time measurement",
                 self.options.output_style,
+                self.options.show_elapsed,
             ))
         } else {
             None

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -112,14 +112,6 @@ fn build_command() -> Command {
                 ),
         )
         .arg(
-            Arg::new("show-elapsed")
-                .long("show-elapsed")
-                .action(ArgAction::SetTrue)
-                .help(
-                    "Show time elapsed since the benchmarking runs were started."
-                )
-        )
-        .arg(
             Arg::new("parameter-scan")
                 .long("parameter-scan")
                 .short('P')
@@ -228,6 +220,17 @@ fn build_command() -> Command {
                    * 'command': order benchmarks in the way they were specified\n  \
                    * 'mean-time': order benchmarks by mean runtime\n"
             ),
+        )
+        .arg(
+            Arg::new("show-elapsed")
+                .long("show-elapsed")
+                .short('E')
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Show time elapsed since the current run was started. \
+                     This is useful for especially long benchmarks to see \
+                     the progress the benchmark has made"
+                )
         )
         .arg(
             Arg::new("time-unit")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -112,6 +112,14 @@ fn build_command() -> Command {
                 ),
         )
         .arg(
+            Arg::new("show-elapsed")
+                .long("show-elapsed")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Show time elapsed since the benchmarking runs were started."
+                )
+        )
+        .arg(
             Arg::new("parameter-scan")
                 .long("parameter-scan")
                 .short('P')

--- a/src/options.rs
+++ b/src/options.rs
@@ -233,6 +233,9 @@ pub struct Options {
 
     /// Which time unit to use when displaying results
     pub time_unit: Option<Unit>,
+
+    /// Show elapsed time since current run start.
+    pub show_elapsed: bool,
 }
 
 impl Default for Options {
@@ -252,6 +255,7 @@ impl Default for Options {
             command_output_policy: CommandOutputPolicy::Null,
             time_unit: None,
             command_input_policy: CommandInputPolicy::Null,
+            show_elapsed: false,
         }
     }
 }
@@ -418,6 +422,10 @@ impl Options {
         } else {
             CommandInputPolicy::Null
         };
+
+        if matches.get_flag("show-elapsed") {
+            options.show_elapsed = true;
+        }
 
         Ok(options)
     }

--- a/src/output/progress_bar.rs
+++ b/src/output/progress_bar.rs
@@ -10,12 +10,22 @@ const TICK_SETTINGS: (&str, u64) = ("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ", 80);
 const TICK_SETTINGS: (&str, u64) = (r"+-x| ", 200);
 
 /// Return a pre-configured progress bar
-pub fn get_progress_bar(length: u64, msg: &str, option: OutputStyleOption) -> ProgressBar {
+pub fn get_progress_bar(
+    length: u64,
+    msg: &str,
+    option: OutputStyleOption,
+    show_elapsed: bool,
+) -> ProgressBar {
+    let template_str = match show_elapsed {
+        true => " {spinner} {msg:<30} {wide_bar} ET {elapsed_precise} ETA {eta_precise} ",
+        false => " {spinner} {msg:<30} {wide_bar} ETA {eta_precise} ",
+    };
+
     let progressbar_style = match option {
         OutputStyleOption::Basic | OutputStyleOption::Color => ProgressStyle::default_bar(),
         _ => ProgressStyle::default_spinner()
             .tick_chars(TICK_SETTINGS.0)
-            .template(" {spinner} {msg:<30} {wide_bar} ETA {eta_precise} ")
+            .template(template_str)
             .expect("no template error"),
     };
 


### PR DESCRIPTION
# Changes
- add  the `-E` and `--show-elapsed` flags to optionally enable a elapsed time counter

# Origin
Recently when I was benchmarking software for my university course, I found that `hyperfine` gives you very little information about how long the current run has been running. This is very unfortunate because you can't tell if your program has possibly deadlocked. This pull request adds the `-E` and `--show-elapsed` flags which will show you for how long the current run is running.