### PR TITLE
Build binaries for aarch64-apple-darwin

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         job:
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-14                      }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
           - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
           - { target: i686-pc-windows-msvc        , os: windows-2019                  }


### PR DESCRIPTION
This uses the macOS 14 Arm64 [beta] runner to build binaries for Apple silicon.