### PR TITLE
Added option to manually specify a reference to compare the results to.

### DIFF
--- a/src/benchmark/relative_speed.rs
+++ b/src/benchmark/relative_speed.rs
@@ -8,14 +8,16 @@ pub struct BenchmarkResultWithRelativeSpeed<'a> {
     pub result: &'a BenchmarkResult,
     pub relative_speed: Scalar,
     pub relative_speed_stddev: Option<Scalar>,
-    pub is_fastest: bool,
+    pub is_reference: bool,
+    // Less means faster
+    pub relative_ordering: Ordering,
 }
 
 pub fn compare_mean_time(l: &BenchmarkResult, r: &BenchmarkResult) -> Ordering {
     l.mean.partial_cmp(&r.mean).unwrap_or(Ordering::Equal)
 }
 
-fn fastest_of(results: &[BenchmarkResult]) -> &BenchmarkResult {
+pub fn fastest_of(results: &[BenchmarkResult]) -> &BenchmarkResult {
     results
         .iter()
         .min_by(|&l, &r| compare_mean_time(l, r))
@@ -24,32 +26,38 @@ fn fastest_of(results: &[BenchmarkResult]) -> &BenchmarkResult {
 
 fn compute_relative_speeds<'a>(
     results: &'a [BenchmarkResult],
-    fastest: &'a BenchmarkResult,
+    reference: &'a BenchmarkResult,
     sort_order: SortOrder,
 ) -> Vec<BenchmarkResultWithRelativeSpeed<'a>> {
     let mut results: Vec<_> = results
         .iter()
         .map(|result| {
-            let is_fastest = result == fastest;
+            let is_reference = result == reference;
+            let relative_ordering = compare_mean_time(result, reference);
 
             if result.mean == 0.0 {
                 return BenchmarkResultWithRelativeSpeed {
                     result,
-                    relative_speed: if is_fastest { 1.0 } else { f64::INFINITY },
+                    relative_speed: if is_reference { 1.0 } else { f64::INFINITY },
                     relative_speed_stddev: None,
-                    is_fastest,
+                    is_reference,
+                    relative_ordering,
                 };
             }
 
-            let ratio = result.mean / fastest.mean;
+            let ratio = match relative_ordering {
+                Ordering::Less => reference.mean / result.mean,
+                Ordering::Equal => 1.0,
+                Ordering::Greater => result.mean / reference.mean,
+            };
 
             // https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulas
             // Covariance asssumed to be 0, i.e. variables are assumed to be independent
-            let ratio_stddev = match (result.stddev, fastest.stddev) {
+            let ratio_stddev = match (result.stddev, reference.stddev) {
                 (Some(result_stddev), Some(fastest_stddev)) => Some(
                     ratio
                         * ((result_stddev / result.mean).powi(2)
-                            + (fastest_stddev / fastest.mean).powi(2))
+                            + (fastest_stddev / reference.mean).powi(2))
                         .sqrt(),
                 ),
                 _ => None,
@@ -59,7 +67,8 @@ fn compute_relative_speeds<'a>(
                 result,
                 relative_speed: ratio,
                 relative_speed_stddev: ratio_stddev,
-                is_fastest,
+                is_reference,
+                relative_ordering,
             }
         })
         .collect();
@@ -72,6 +81,18 @@ fn compute_relative_speeds<'a>(
     }
 
     results
+}
+
+pub fn compute_with_check_from_reference<'a>(
+    results: &'a [BenchmarkResult],
+    reference: &'a BenchmarkResult,
+    sort_order: SortOrder,
+) -> Option<Vec<BenchmarkResultWithRelativeSpeed<'a>>> {
+    if fastest_of(results).mean == 0.0 || reference.mean == 0.0 {
+        return None;
+    }
+
+    Some(compute_relative_speeds(results, reference, sort_order))
 }
 
 pub fn compute_with_check(

--- a/src/benchmark/relative_speed.rs
+++ b/src/benchmark/relative_speed.rs
@@ -156,6 +156,20 @@ fn test_compute_relative_speed() {
 }
 
 #[test]
+fn test_compute_relative_speed_with_reference() {
+    use approx::assert_relative_eq;
+
+    let results = vec![create_result("cmd2", 2.0), create_result("cmd3", 5.0)];
+    let reference = create_result("cmd2", 4.0);
+
+    let annotated_results =
+        compute_with_check_from_reference(&results, &reference, SortOrder::Command).unwrap();
+
+    assert_relative_eq!(2.0, annotated_results[0].relative_speed);
+    assert_relative_eq!(1.25, annotated_results[1].relative_speed);
+}
+
+#[test]
 fn test_compute_relative_speed_for_zero_times() {
     let results = vec![create_result("cmd1", 1.0), create_result("cmd2", 0.0)];
 

--- a/src/benchmark/scheduler.rs
+++ b/src/benchmark/scheduler.rs
@@ -96,19 +96,30 @@ impl<'a> Scheduler<'a> {
                     );
 
                     for item in others {
+                        let stddev = if let Some(stddev) = item.relative_speed_stddev {
+                            format!(" ± {}", format!("{:.2}", stddev).green())
+                        } else {
+                            "".into()
+                        };
                         let comparator = match item.relative_ordering {
-                            Ordering::Less => "slower",
-                            Ordering::Greater => "faster",
-                            Ordering::Equal => "as fast",
+                            Ordering::Less => format!(
+                                "{}{} times slower than",
+                                format!("{:8.2}", item.relative_speed).bold().green(),
+                                stddev
+                            ),
+                            Ordering::Greater => format!(
+                                "{}{} times faster than",
+                                format!("{:8.2}", item.relative_speed).bold().green(),
+                                stddev
+                            ),
+                            Ordering::Equal => format!(
+                                "    As fast ({}{}) as",
+                                format!("{:.2}", item.relative_speed).bold().green(),
+                                stddev
+                            ),
                         };
                         println!(
-                            "{}{} times {} than {}",
-                            format!("{:8.2}", item.relative_speed).bold().green(),
-                            if let Some(stddev) = item.relative_speed_stddev {
-                                format!(" ± {}", format!("{stddev:.2}").green())
-                            } else {
-                                "".into()
-                            },
+                            "{} {}",
                             comparator,
                             &item.result.command_with_unused_parameters.magenta()
                         );

--- a/src/benchmark/scheduler.rs
+++ b/src/benchmark/scheduler.rs
@@ -1,10 +1,10 @@
-use colored::*;
-
 use super::benchmark_result::BenchmarkResult;
 use super::executor::{Executor, MockExecutor, RawExecutor, ShellExecutor};
 use super::{relative_speed, Benchmark};
+use colored::*;
+use std::cmp::Ordering;
 
-use crate::command::Commands;
+use crate::command::{Command, Commands};
 use crate::export::ExportManager;
 use crate::options::{ExecutorKind, Options, OutputStyleOption, SortOrder};
 
@@ -38,9 +38,15 @@ impl<'a> Scheduler<'a> {
             ExecutorKind::Shell(ref shell) => Box::new(ShellExecutor::new(shell, self.options)),
         };
 
+        let reference = self
+            .options
+            .reference_command
+            .as_ref()
+            .map(|cmd| Command::new(None, cmd));
+
         executor.calibrate()?;
 
-        for (number, cmd) in self.commands.iter().enumerate() {
+        for (number, cmd) in reference.iter().chain(self.commands.iter()).enumerate() {
             self.results
                 .push(Benchmark::new(number, cmd, self.options, &*executor).run()?);
 
@@ -65,31 +71,45 @@ impl<'a> Scheduler<'a> {
             return;
         }
 
-        if let Some(annotated_results) = relative_speed::compute_with_check(
+        let reference = self
+            .options
+            .reference_command
+            .as_ref()
+            .map(|_| &self.results[0])
+            .unwrap_or_else(|| relative_speed::fastest_of(&self.results));
+
+        if let Some(annotated_results) = relative_speed::compute_with_check_from_reference(
             &self.results,
+            reference,
             self.options.sort_order_speed_comparison,
         ) {
             match self.options.sort_order_speed_comparison {
                 SortOrder::MeanTime => {
                     println!("{}", "Summary".bold());
 
-                    let fastest = annotated_results.iter().find(|r| r.is_fastest).unwrap();
-                    let others = annotated_results.iter().filter(|r| !r.is_fastest);
+                    let reference = annotated_results.iter().find(|r| r.is_reference).unwrap();
+                    let others = annotated_results.iter().filter(|r| !r.is_reference);
 
                     println!(
                         "  {} ran",
-                        fastest.result.command_with_unused_parameters.cyan()
+                        reference.result.command_with_unused_parameters.cyan()
                     );
 
                     for item in others {
+                        let comparator = match item.relative_ordering {
+                            Ordering::Less => "slower",
+                            Ordering::Greater => "faster",
+                            Ordering::Equal => "as fast",
+                        };
                         println!(
-                            "{}{} times faster than {}",
+                            "{}{} times {} than {}",
                             format!("{:8.2}", item.relative_speed).bold().green(),
                             if let Some(stddev) = item.relative_speed_stddev {
                                 format!(" ± {}", format!("{stddev:.2}").green())
                             } else {
                                 "".into()
                             },
+                            comparator,
                             &item.result.command_with_unused_parameters.magenta()
                         );
                     }
@@ -101,7 +121,7 @@ impl<'a> Scheduler<'a> {
                         println!(
                             "  {}{}  {}",
                             format!("{:10.2}", item.relative_speed).bold().green(),
-                            if item.is_fastest {
+                            if item.is_reference {
                                 "        ".into()
                             } else if let Some(stddev) = item.relative_speed_stddev {
                                 format!(" ± {}", format!("{stddev:5.2}").green())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,6 +87,16 @@ fn build_command() -> Command {
                 ),
         )
         .arg(
+            Arg::new("reference")
+                .long("reference")
+                .action(ArgAction::Set)
+                .value_name("CMD")
+                .help(
+                    "The reference command for the relative comparison of results. \
+                    If this is unset, results are compared with the fastest command as reference."
+                )
+        )
+        .arg(
             Arg::new("prepare")
                 .long("prepare")
                 .short('p')

--- a/src/export/markup.rs
+++ b/src/export/markup.rs
@@ -56,7 +56,7 @@ pub trait MarkupExporter {
             let min_str = format_duration_value(measurement.min, Some(unit)).0;
             let max_str = format_duration_value(measurement.max, Some(unit)).0;
             let rel_str = format!("{:.2}", entry.relative_speed);
-            let rel_stddev_str = if entry.is_fastest {
+            let rel_stddev_str = if entry.is_reference {
                 "".into()
             } else if let Some(stddev) = entry.relative_speed_stddev {
                 format!(" ± {stddev:.2}")

--- a/src/options.rs
+++ b/src/options.rs
@@ -204,6 +204,9 @@ pub struct Options {
     /// Whether or not to ignore non-zero exit codes
     pub command_failure_action: CmdFailureAction,
 
+    // Command to use as a reference for relative speed comparison
+    pub reference_command: Option<String>,
+
     /// Command(s) to run before each timing run
     pub preparation_command: Option<Vec<String>>,
 
@@ -245,6 +248,7 @@ impl Default for Options {
             warmup_count: 0,
             min_benchmarking_time: 3.0,
             command_failure_action: CmdFailureAction::RaiseError,
+            reference_command: None,
             preparation_command: None,
             conclusion_command: None,
             setup_command: None,
@@ -303,6 +307,8 @@ impl Options {
         };
 
         options.setup_command = matches.get_one::<String>("setup").map(String::from);
+
+        options.reference_command = matches.get_one::<String>("reference").map(String::from);
 
         options.preparation_command = matches
             .get_many::<String>("prepare")

--- a/src/options.rs
+++ b/src/options.rs
@@ -437,21 +437,25 @@ impl Options {
     }
 
     pub fn validate_against_command_list(&self, commands: &Commands) -> Result<()> {
+        let num_commands = commands.num_commands()
+            + if self.reference_command.is_some() {
+                1
+            } else {
+                0
+            };
         if let Some(preparation_command) = &self.preparation_command {
             ensure!(
-                preparation_command.len() <= 1
-                    || commands.num_commands() == preparation_command.len(),
+                preparation_command.len() <= 1 || num_commands == preparation_command.len(),
                 "The '--prepare' option has to be provided just once or N times, where N is the \
-             number of benchmark commands."
+             number of benchmark commands including a potential reference."
             );
         }
 
         if let Some(conclusion_command) = &self.conclusion_command {
             ensure!(
-                conclusion_command.len() <= 1
-                    || commands.num_commands() == conclusion_command.len(),
+                conclusion_command.len() <= 1 || num_commands == conclusion_command.len(),
                 "The '--conclude' option has to be provided just once or N times, where N is the \
-             number of benchmark commands."
+             number of benchmark commands including a potential reference."
             );
         }
 

--- a/tests/execution_order_tests.rs
+++ b/tests/execution_order_tests.rs
@@ -54,6 +54,11 @@ impl ExecutionOrderTest {
         self.command(output)
     }
 
+    fn reference(&mut self, output: &str) -> &mut Self {
+        self.arg("--reference");
+        self.command(output)
+    }
+
     fn conclude(&mut self, output: &str) -> &mut Self {
         self.arg("--conclude");
         self.command(output)
@@ -362,5 +367,197 @@ fn multiple_parameter_values() {
         .expect_output("command 2 b")
         .expect_output("command 3 b")
         .expect_output("command 3 b")
+        .run();
+}
+
+#[test]
+fn reference_is_executed_first() {
+    ExecutionOrderTest::new()
+        .arg("--runs=1")
+        .reference("reference")
+        .command("command 1")
+        .command("command 2")
+        .expect_output("reference")
+        .expect_output("command 1")
+        .expect_output("command 2")
+        .run();
+}
+
+#[test]
+fn reference_is_executed_first_parameter_value() {
+    ExecutionOrderTest::new()
+        .arg("--runs=2")
+        .reference("reference")
+        .arg("--parameter-list")
+        .arg("number")
+        .arg("1,2,3")
+        .command("command {number}")
+        .expect_output("reference")
+        .expect_output("reference")
+        .expect_output("command 1")
+        .expect_output("command 1")
+        .expect_output("command 2")
+        .expect_output("command 2")
+        .expect_output("command 3")
+        .expect_output("command 3")
+        .run();
+}
+
+#[test]
+fn reference_is_executed_separately_from_commands() {
+    ExecutionOrderTest::new()
+        .arg("--runs=1")
+        .reference("command 1")
+        .command("command 1")
+        .command("command 2")
+        .expect_output("command 1")
+        .expect_output("command 1")
+        .expect_output("command 2")
+        .run();
+}
+
+#[test]
+fn setup_prepare_reference_conclude_cleanup_combined() {
+    ExecutionOrderTest::new()
+        .arg("--warmup=1")
+        .arg("--runs=2")
+        .setup("setup")
+        .prepare("prepare")
+        .reference("reference")
+        .command("command1")
+        .command("command2")
+        .conclude("conclude")
+        .cleanup("cleanup")
+        // reference
+        .expect_output("setup")
+        .expect_output("prepare")
+        .expect_output("reference")
+        .expect_output("conclude")
+        .expect_output("prepare")
+        .expect_output("reference")
+        .expect_output("conclude")
+        .expect_output("prepare")
+        .expect_output("reference")
+        .expect_output("conclude")
+        .expect_output("cleanup")
+        // 1
+        .expect_output("setup")
+        .expect_output("prepare")
+        .expect_output("command1")
+        .expect_output("conclude")
+        .expect_output("prepare")
+        .expect_output("command1")
+        .expect_output("conclude")
+        .expect_output("prepare")
+        .expect_output("command1")
+        .expect_output("conclude")
+        .expect_output("cleanup")
+        // 2
+        .expect_output("setup")
+        .expect_output("prepare")
+        .expect_output("command2")
+        .expect_output("conclude")
+        .expect_output("prepare")
+        .expect_output("command2")
+        .expect_output("conclude")
+        .expect_output("prepare")
+        .expect_output("command2")
+        .expect_output("conclude")
+        .expect_output("cleanup")
+        .run();
+}
+
+#[test]
+fn setup_separete_prepare_separate_conclude_cleanup_combined() {
+    ExecutionOrderTest::new()
+        .arg("--warmup=1")
+        .arg("--runs=2")
+        .setup("setup")
+        .cleanup("cleanup")
+        .prepare("prepare1")
+        .command("command1")
+        .conclude("conclude1")
+        .prepare("prepare2")
+        .command("command2")
+        .conclude("conclude2")
+        // 1
+        .expect_output("setup")
+        .expect_output("prepare1")
+        .expect_output("command1")
+        .expect_output("conclude1")
+        .expect_output("prepare1")
+        .expect_output("command1")
+        .expect_output("conclude1")
+        .expect_output("prepare1")
+        .expect_output("command1")
+        .expect_output("conclude1")
+        .expect_output("cleanup")
+        // 2
+        .expect_output("setup")
+        .expect_output("prepare2")
+        .expect_output("command2")
+        .expect_output("conclude2")
+        .expect_output("prepare2")
+        .expect_output("command2")
+        .expect_output("conclude2")
+        .expect_output("prepare2")
+        .expect_output("command2")
+        .expect_output("conclude2")
+        .expect_output("cleanup")
+        .run();
+}
+
+#[test]
+fn setup_separete_prepare_reference_separate_conclude_cleanup_combined() {
+    ExecutionOrderTest::new()
+        .arg("--warmup=1")
+        .arg("--runs=2")
+        .setup("setup")
+        .cleanup("cleanup")
+        .prepare("prepareref")
+        .reference("reference")
+        .conclude("concluderef")
+        .prepare("prepare1")
+        .command("command1")
+        .conclude("conclude1")
+        .prepare("prepare2")
+        .command("command2")
+        .conclude("conclude2")
+        // reference
+        .expect_output("setup")
+        .expect_output("prepareref")
+        .expect_output("reference")
+        .expect_output("concluderef")
+        .expect_output("prepareref")
+        .expect_output("reference")
+        .expect_output("concluderef")
+        .expect_output("prepareref")
+        .expect_output("reference")
+        .expect_output("concluderef")
+        .expect_output("cleanup")
+        // 1
+        .expect_output("setup")
+        .expect_output("prepare1")
+        .expect_output("command1")
+        .expect_output("conclude1")
+        .expect_output("prepare1")
+        .expect_output("command1")
+        .expect_output("conclude1")
+        .expect_output("prepare1")
+        .expect_output("command1")
+        .expect_output("conclude1")
+        .expect_output("cleanup")
+        // 2
+        .expect_output("setup")
+        .expect_output("prepare2")
+        .expect_output("command2")
+        .expect_output("conclude2")
+        .expect_output("prepare2")
+        .expect_output("command2")
+        .expect_output("conclude2")
+        .expect_output("prepare2")
+        .expect_output("command2")
+        .expect_output("conclude2")
+        .expect_output("cleanup")
         .run();
 }

--- a/tests/execution_order_tests.rs
+++ b/tests/execution_order_tests.rs
@@ -468,7 +468,7 @@ fn setup_prepare_reference_conclude_cleanup_combined() {
 }
 
 #[test]
-fn setup_separete_prepare_separate_conclude_cleanup_combined() {
+fn setup_separate_prepare_separate_conclude_cleanup_combined() {
     ExecutionOrderTest::new()
         .arg("--warmup=1")
         .arg("--runs=2")
@@ -508,7 +508,7 @@ fn setup_separete_prepare_separate_conclude_cleanup_combined() {
 }
 
 #[test]
-fn setup_separete_prepare_reference_separate_conclude_cleanup_combined() {
+fn setup_separate_prepare_reference_separate_conclude_cleanup_combined() {
     ExecutionOrderTest::new()
         .arg("--warmup=1")
         .arg("--runs=2")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -63,11 +63,35 @@ fn fails_with_wrong_number_of_prepare_options() {
 
     hyperfine()
         .arg("--runs=1")
+        .arg("--prepare=echo ref")
+        .arg("--prepare=echo a")
+        .arg("--prepare=echo b")
+        .arg("--reference=echo ref")
+        .arg("echo a")
+        .arg("echo b")
+        .assert()
+        .success();
+
+    hyperfine()
+        .arg("--runs=1")
         .arg("--prepare=echo a")
         .arg("--prepare=echo b")
         .arg("echo a")
         .arg("echo b")
         .arg("echo c")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "The '--prepare' option has to be provided",
+        ));
+
+    hyperfine()
+        .arg("--runs=1")
+        .arg("--prepare=echo a")
+        .arg("--prepare=echo b")
+        .arg("--reference=echo ref")
+        .arg("echo a")
+        .arg("echo b")
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -88,11 +112,35 @@ fn fails_with_wrong_number_of_conclude_options() {
 
     hyperfine()
         .arg("--runs=1")
+        .arg("--conclude=echo ref")
+        .arg("--conclude=echo a")
+        .arg("--conclude=echo b")
+        .arg("--reference=echo ref")
+        .arg("echo a")
+        .arg("echo b")
+        .assert()
+        .success();
+
+    hyperfine()
+        .arg("--runs=1")
         .arg("--conclude=echo a")
         .arg("--conclude=echo b")
         .arg("echo a")
         .arg("echo b")
         .arg("echo c")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "The '--conclude' option has to be provided",
+        ));
+
+    hyperfine()
+        .arg("--runs=1")
+        .arg("--conclude=echo a")
+        .arg("--conclude=echo b")
+        .arg("--reference=echo ref")
+        .arg("echo a")
+        .arg("echo b")
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -414,6 +462,20 @@ fn shows_benchmark_comparison_with_relative_times() {
 }
 
 #[test]
+fn shows_benchmark_comparison_relative_to_reference() {
+    hyperfine_debug()
+        .arg("--reference=sleep 2.0")
+        .arg("sleep 1.0")
+        .arg("sleep 3.0")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("2.00 ± 0.00 times slower")
+                .and(predicate::str::contains("1.50 ± 0.00 times faster")),
+        );
+}
+
+#[test]
 fn performs_all_benchmarks_in_parameter_scan() {
     hyperfine_debug()
         .arg("--parameter-scan")
@@ -431,6 +493,29 @@ fn performs_all_benchmarks_in_parameter_scan() {
                 .and(predicate::str::contains("Benchmark 3: sleep 40"))
                 .and(predicate::str::contains("Benchmark 4: sleep 45"))
                 .and(predicate::str::contains("Benchmark 5: sleep 50").not()),
+        );
+}
+
+#[test]
+fn performs_reference_and_all_benchmarks_in_parameter_scan() {
+    hyperfine_debug()
+        .arg("--reference=sleep 25")
+        .arg("--parameter-scan")
+        .arg("time")
+        .arg("30")
+        .arg("45")
+        .arg("--parameter-step-size")
+        .arg("5")
+        .arg("sleep {time}")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Benchmark 1: sleep 25")
+                .and(predicate::str::contains("Benchmark 2: sleep 30"))
+                .and(predicate::str::contains("Benchmark 3: sleep 35"))
+                .and(predicate::str::contains("Benchmark 4: sleep 40"))
+                .and(predicate::str::contains("Benchmark 5: sleep 45"))
+                .and(predicate::str::contains("Benchmark 6: sleep 50").not()),
         );
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -462,6 +462,24 @@ fn shows_benchmark_comparison_with_relative_times() {
 }
 
 #[test]
+fn shows_benchmark_comparison_with_same_time() {
+    hyperfine_debug()
+        .arg("--command-name=A")
+        .arg("--command-name=B")
+        .arg("sleep 1.0")
+        .arg("sleep 1.0")
+        .arg("sleep 2.0")
+        .arg("sleep 1000.0")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("As fast (1.00 ± 0.00) as")
+                .and(predicate::str::contains("2.00 ± 0.00 times faster"))
+                .and(predicate::str::contains("1000.00 ± 0.00 times faster")),
+        );
+}
+
+#[test]
 fn shows_benchmark_comparison_relative_to_reference() {
     hyperfine_debug()
         .arg("--reference=sleep 2.0")


### PR DESCRIPTION
I was interested in the functionality discussed in https://github.com/sharkdp/hyperfine/pull/579 and https://github.com/sharkdp/hyperfine/issues/577.

Sadly the former PR has been stale for over a year.

So i have tried to effectively take the work from there, make it fit with the changes that have happend since then and also address the comments in the PR.

There are currently still two points that i am myself unsure about.

I have used the standard `std::cmp::Ordering` for the ordering compared to the reference. However, i feel that the naming is not actually clear at a first glance. Namely that `Ordering::Less` corresponds to a faster time (the runtime is less). It might be worth to create a distinct enum that maps to this (converts from) as suggested in the original PR review.

I am also not sure if the statements `faster than` and `slower than` are the best. Particularly the latter feels a bit unintuitive to me.
Maybe something like `0.2 times as fast` would be better than `5.0 times slower`?