### PR TITLE
Add flox install

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ On NixOS, hyperfine can be installed [from the official repositories](https://ni
 nix-env -i hyperfine
 ```
 
+### On Flox
+
+On Flox, hyperfine can be installed as follows.
+```
+flox install hyperfine
+```
+Hyperfine's version in Flox follows that of Nix.
+
 ### On openSUSE
 
 On openSUSE, hyperfine can be installed [from the official repositories](https://software.opensuse.org/package/hyperfine):


### PR DESCRIPTION
`hyperfine` is available, and seems to be working in Flox!
Since Flox and Nix are closely related, I added the Flox install section under that of NixOS. 
If you have any questions about Flox, please, let me know. 😊