### PR TITLE
Add geometric mean calculation to analysis script

### DIFF
--- a/scripts/advanced_statistics.py
+++ b/scripts/advanced_statistics.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import numpy as np
+from scipy.stats import gmean
 
 parser = argparse.ArgumentParser()
 parser.add_argument("file", help="JSON file with benchmark results")
@@ -25,6 +26,7 @@ for command, ts in zip(commands, times):
     print("Command '{}'".format(command))
     print("  runs:   {:8d}".format(len(ts)))
     print("  mean:   {:8.3f} s".format(np.mean(ts)))
+    print("  geomean:{:8.3f} s".format(gmean(ts)))
     print("  stddev: {:8.3f} s".format(np.std(ts, ddof=1)))
     print("  median: {:8.3f} s".format(np.median(ts)))
     print("  min:    {:8.3f} s".format(np.min(ts)))


### PR DESCRIPTION
geometric mean can be useful at times.
scipy's geometric mean calculation handles negatives and zeros gracefully as well.

example output

```shell
Command 'sleep 0.020'
  runs:         78
  mean:      0.026 s
  geomean:   0.025 s
  stddev:    0.003 s
  median:    0.025 s
  min:       0.021 s
  max:       0.035 s

  percentiles:
     P_05 .. P_95:    0.021 s .. 0.031 s
     P_25 .. P_75:    0.023 s .. 0.028 s  (IQR = 0.005 s)
```