### PR TITLE
fix build warning proposal

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -134,7 +134,7 @@ impl<'a> Command<'a> {
 pub struct Commands<'a>(Vec<Command<'a>>);
 
 impl<'a> Commands<'a> {
-    pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands> {
+    pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands<'a>> {
         let command_names = matches.get_many::<String>("command-name");
         let command_strings = matches
             .get_many::<String>("command")


### PR DESCRIPTION
```rust
warning: elided lifetime has a name
   --> src/command.rs:137:66
    |
136 | impl<'a> Commands<'a> {
    |      -- lifetime `'a` declared here
137 |     pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands> {
    |                                                                  ^^^^^^^^ this elided lifetime gets resolved as `'
```