### PR TITLE
Multiple output policies

### DIFF
--- a/doc/hyperfine.1
+++ b/doc/hyperfine.1
@@ -290,6 +290,11 @@ Don't redirect the output at all (same as \&'\-\-show\-output').
 .IP "<FILE>"
 Write the output to the given file.
 .RE
+.IP
+This option can be specified once for all commands or multiple times,
+once for each command. Note: If you want to log the output of each and
+every iteration, you can use a shell redirection and the $HYPERFINE_ITERATION
+environment variable: 'my-command > output-${HYPERFINE_ITERATION}.log'
 .HP
 \fB\-\-input\fR \fIWHERE\fP
 .IP

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -327,7 +327,7 @@ fn build_command() -> Command {
             Arg::new("output")
                 .long("output")
                 .conflicts_with("show-output")
-                .action(ArgAction::Set)
+                .action(ArgAction::Append)
                 .value_name("WHERE")
                 .help(
                     "Control where the output of the benchmark is redirected. Note \
@@ -343,7 +343,11 @@ fn build_command() -> Command {
                      \n  \
                        inherit:  Don't redirect the output at all (same as '--show-output').\n\
                      \n  \
-                       <FILE>:   Write the output to the given file.",
+                       <FILE>:   Write the output to the given file.\n\n\
+                    This option can be specified once for all commands or multiple times, once for \
+                    each command. Note: If you want to log the output of each and every iteration, \
+                    you can use a shell redirection and the '$HYPERFINE_ITERATION' environment variable:\n    \
+                    hyperfine 'my-command > output-${HYPERFINE_ITERATION}.log'\n\n",
                 ),
         )
         .arg(

--- a/src/command.rs
+++ b/src/command.rs
@@ -251,8 +251,8 @@ impl<'a> Commands<'a> {
         self.0.iter()
     }
 
-    pub fn num_commands(&self) -> usize {
-        self.0.len()
+    pub fn num_commands(&self, has_reference_command: bool) -> usize {
+        self.0.len() + if has_reference_command { 1 } else { 0 }
     }
 
     /// Finds all the strings that appear multiple times in the input iterator, returning them in

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn run() -> Result<()> {
     colored::control::set_virtual_terminal(true).unwrap();
 
     let cli_arguments = get_cli_arguments(env::args_os());
-    let options = Options::from_cli_arguments(&cli_arguments)?;
+    let mut options = Options::from_cli_arguments(&cli_arguments)?;
     let commands = Commands::from_cli_arguments(&cli_arguments)?;
     let export_manager = ExportManager::from_cli_arguments(&cli_arguments, options.time_unit)?;
 


### PR DESCRIPTION
- Allow `--output` to appear *exactly once* or *exactly N times*, enabling several new use cases like `hyperfine --output=cmd1.log cmd1 --output=cmd2.log cmd2` or `hyperfine --output=null cmd --output=./file cmd`.
- In the `--help` text for `--output`, mention the `HYPERFINE_ITERATION` environment variable for users who want to log each and every iteration.

closes #529