### PR TITLE
Show singular  'warmup run' text for single warmup

### DIFF
--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -201,9 +201,13 @@ impl<'a> Benchmark<'a> {
         // Warmup phase
         if self.options.warmup_count > 0 {
             let progress_bar = if self.options.output_style != OutputStyleOption::Disabled {
+                let mut msg = "Performing warmup runs";
+                if self.options.warmup_count == 1 {
+                    msg = "Performing warmup run";
+                }
                 Some(get_progress_bar(
                     self.options.warmup_count,
-                    "Performing warmup runs",
+                    msg,
                     self.options.output_style,
                 ))
             } else {


### PR DESCRIPTION
If the user only requests a single warmup, we still show `Performing warmup runs`, which might be confusing. Therefore, this uses the singular `Performing warmup run` as message for the progress bar if only a single warmup was requested.

## How to test?

1. Run `hyperfine --warmup 2 'sleep 10'`
2. See the usual `Performing warmup runs` message
3. Run `hyperfine --warmup 1 'sleep 10'`
4. See the new `Performing warmup run` (singular!) message in the progress bar

## Screenshots

| Before | After |
| --- | --- |
| <img width="317" alt="image" src="https://github.com/user-attachments/assets/efcb3ae5-ce23-4a56-b5f1-d83abcee2843" /> | <img width="322" alt="image" src="https://github.com/user-attachments/assets/3dc23b21-087f-4498-8d02-e5c9da010657" /> |
