### PR TITLE
Add link to Venz

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ visualize changes in benchmark timings across your Git history.
 [Bencher](https://github.com/bencherdev/bencher) is a continuous benchmarking tool that supports `hyperfine` to
 track benchmarks and catch performance regressions in CI.
 
+Drop hyperfine JSON outputs onto the [Venz](https://try.venz.dev) chart to visualize the results,
+and manage hyperfine configurations.
+
 Make sure to check out the [`scripts` folder](https://github.com/sharkdp/hyperfine/tree/master/scripts)
 in this repository for a set of tools to work with `hyperfine` benchmark results.
 


### PR DESCRIPTION
Add link to [Venz](https://try.venz.dev). Also see #786.