### PR TITLE
Add option to name reference command

### DIFF
--- a/src/benchmark/scheduler.rs
+++ b/src/benchmark/scheduler.rs
@@ -42,7 +42,7 @@ impl<'a> Scheduler<'a> {
             .options
             .reference_command
             .as_ref()
-            .map(|cmd| Command::new(None, cmd));
+            .map(|cmd| Command::new(self.options.reference_name.as_deref(), cmd));
 
         executor.calibrate()?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,14 @@ fn build_command() -> Command {
                 )
         )
         .arg(
+            Arg::new("reference-name")
+                .long("reference-name")
+                .action(ArgAction::Set)
+                .value_name("CMD")
+                .help("Give a meaningful name to the reference command.")
+                .requires("reference")
+        )
+        .arg(
             Arg::new("prepare")
                 .long("prepare")
                 .short('p')

--- a/src/options.rs
+++ b/src/options.rs
@@ -208,6 +208,9 @@ pub struct Options {
     // Command to use as a reference for relative speed comparison
     pub reference_command: Option<String>,
 
+    // Name of the reference command
+    pub reference_name: Option<String>,
+
     /// Command(s) to run before each timing run
     pub preparation_command: Option<Vec<String>>,
 
@@ -250,6 +253,7 @@ impl Default for Options {
             min_benchmarking_time: 3.0,
             command_failure_action: CmdFailureAction::RaiseError,
             reference_command: None,
+            reference_name: None,
             preparation_command: None,
             conclusion_command: None,
             setup_command: None,
@@ -310,6 +314,9 @@ impl Options {
         options.setup_command = matches.get_one::<String>("setup").map(String::from);
 
         options.reference_command = matches.get_one::<String>("reference").map(String::from);
+        options.reference_name = matches
+            .get_one::<String>("reference-name")
+            .map(String::from);
 
         options.preparation_command = matches
             .get_many::<String>("prepare")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -500,6 +500,18 @@ fn shows_benchmark_comparison_relative_to_reference() {
 }
 
 #[test]
+fn shows_reference_name() {
+    hyperfine_debug()
+        .arg("--reference=sleep 2.0")
+        .arg("--reference-name=refabc123")
+        .arg("sleep 1.0")
+        .arg("sleep 3.0")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Benchmark 1: refabc123"));
+}
+
+#[test]
 fn performs_all_benchmarks_in_parameter_scan() {
     hyperfine_debug()
         .arg("--parameter-scan")


### PR DESCRIPTION
Add --reference-name option to give a reference command a name.

This was discussed in the PR that added --reference, #744, but was unfortunately never implemented.
