### PR TITLE
Run the program until it prints the given text in the output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ windows-sys = { version = "0.59", features = [
 once_cell = "1.19"
 
 [target.'cfg(target_os="linux")'.dependencies]
-nix = { version = "0.29", features = ["zerocopy"] }
+nix = { version = "0.29", features = ["zerocopy", "signal"] }
 
 [dependencies.clap]
 version = "4"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@
 
 A command-line benchmarking tool.
 
+## Personal Fork Changes
+
+This fork includes the following modifications for more accurate low-level benchmarking:
+
+### CPU Pinning (`--cpu`)
+Pin the benchmarked command to a specific CPU core using `sched_setaffinity`. This reduces noise from CPU migration during benchmarks.
+```sh
+hyperfine --cpu 0 --shell=none './my_program'
+```
+
+### Scheduling Priority (`--priority`)
+Set the scheduling policy of the benchmarked command to `realtime` (SCHED_FIFO) or `idle` (SCHED_IDLE) for reduced scheduler interference.
+```sh
+hyperfine --priority realtime --shell=none './my_program'
+```
+Note: Realtime priority requires `CAP_SYS_NICE` capability or root. Grant it with:
+```sh
+sudo setcap cap_sys_nice+ep $(which hyperfine)
+```
+
+### Post-Fork Timing (Linux)
+Timing now starts after `fork()` but before `exec()`, excluding fork overhead from measurements. This provides more accurate timing for fast-starting programs.
+
+### Per-Child Memory Measurement (Linux)
+Uses `wait4()` syscall to get per-child `rusage` instead of cumulative `getrusage(RUSAGE_CHILDREN)`, fixing memory reporting accuracy when running multiple benchmarks.
+
+---
+
 **Demo**: Benchmarking [`fd`](https://github.com/sharkdp/fd) and
 [`find`](https://www.gnu.org/software/findutils/):
 

--- a/src/benchmark/benchmark_result.rs
+++ b/src/benchmark/benchmark_result.rs
@@ -42,9 +42,17 @@ pub struct BenchmarkResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub times: Option<Vec<Second>>,
 
-    /// Maximum memory usage of the process, in bytes
+    /// Memory usage measurements of the process, in bytes (one per run)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_usage_byte: Option<Vec<u64>>,
+
+    /// Minimum memory usage across all runs, in bytes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_min: Option<u64>,
+
+    /// Peak memory usage (max across all runs), in bytes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_max: Option<u64>,
 
     /// Exit codes of all command invocations
     pub exit_codes: Vec<Option<i32>>,

--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -30,6 +30,14 @@ impl BenchmarkIteration {
             BenchmarkIteration::Benchmark(i) => Some(format!("{}", i)),
         }
     }
+
+    /// Returns `true` if the benchmark iteration is [`NonBenchmarkRun`].
+    ///
+    /// [`NonBenchmarkRun`]: BenchmarkIteration::NonBenchmarkRun
+    #[must_use]
+    pub fn is_non_benchmark_run(&self) -> bool {
+        matches!(self, Self::NonBenchmarkRun)
+    }
 }
 
 pub trait Executor {
@@ -65,7 +73,12 @@ fn run_command_and_measure_common(
 ) -> Result<TimerResult> {
     let stdin = command_input_policy.get_stdin()?;
     let (stdout, stderr) = command_output_policy.get_stdout_stderr()?;
-    let until_text = command_output_policy.get_until_text();
+    let until_text = if iteration.is_non_benchmark_run() {
+        None
+    } else {
+        command_output_policy.get_until_text()
+    };
+
     command.stdin(stdin).stdout(stdout).stderr(stderr);
 
     command.env(

--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -65,6 +65,7 @@ fn run_command_and_measure_common(
 ) -> Result<TimerResult> {
     let stdin = command_input_policy.get_stdin()?;
     let (stdout, stderr) = command_output_policy.get_stdout_stderr()?;
+    let until_text = command_output_policy.get_until_text();
     command.stdin(stdin).stdout(stdout).stderr(stderr);
 
     command.env(
@@ -76,7 +77,7 @@ fn run_command_and_measure_common(
         command.env("HYPERFINE_ITERATION", value);
     }
 
-    let result = execute_and_measure(command)
+    let result = execute_and_measure(command, until_text)
         .with_context(|| format!("Failed to run command '{command_name}'"))?;
 
     if command_failure_action == CmdFailureAction::RaiseError && !result.status.success() {

--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -2,9 +2,13 @@
 use std::os::windows::process::CommandExt;
 use std::process::ExitStatus;
 
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
+
 use crate::command::Command;
 use crate::options::{
-    CmdFailureAction, CommandInputPolicy, CommandOutputPolicy, Options, OutputStyleOption, Shell,
+    CmdFailureAction, CommandInputPolicy, CommandOutputPolicy, Options, OutputStyleOption,
+    SchedulingPolicy, Shell,
 };
 use crate::output::progress_bar::get_progress_bar;
 use crate::timer::{execute_and_measure, TimerResult};
@@ -15,6 +19,54 @@ use super::timing_result::TimingResult;
 
 use anyhow::{bail, Context, Result};
 use statistical::mean;
+
+/// Set CPU affinity and scheduling policy in the child process before exec.
+/// This runs after fork() but before exec().
+#[cfg(target_os = "linux")]
+fn setup_process_priority(
+    cpu_affinity: Option<usize>,
+    scheduling_priority: Option<SchedulingPolicy>,
+) -> impl FnMut() -> std::io::Result<()> {
+    move || {
+        if let Some(cpu) = cpu_affinity {
+            unsafe {
+                let mut set: libc::cpu_set_t = std::mem::zeroed();
+                libc::CPU_SET(cpu, &mut set);
+                if libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+        }
+
+        if let Some(policy) = scheduling_priority {
+            unsafe {
+                let (sched_policy, priority) = match policy {
+                    SchedulingPolicy::Realtime => (libc::SCHED_FIFO, 99),
+                    SchedulingPolicy::Idle => (libc::SCHED_IDLE, 0),
+                };
+                let param = libc::sched_param {
+                    sched_priority: priority,
+                };
+                if libc::sched_setscheduler(0, sched_policy, &param) != 0 {
+                    let err = std::io::Error::last_os_error();
+                    if err.raw_os_error() == Some(libc::EPERM) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!(
+                                "Permission denied setting {:?} scheduler. \
+                                 Try: sudo setcap cap_sys_nice+ep $(which hyperfine)",
+                                policy
+                            ),
+                        ));
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
 
 pub enum BenchmarkIteration {
     NonBenchmarkRun,
@@ -70,6 +122,8 @@ fn run_command_and_measure_common(
     command_input_policy: &CommandInputPolicy,
     command_output_policy: &CommandOutputPolicy,
     command_name: &str,
+    cpu_affinity: Option<usize>,
+    scheduling_priority: Option<SchedulingPolicy>,
 ) -> Result<TimerResult> {
     let stdin = command_input_policy.get_stdin()?;
     let (stdout, stderr) = command_output_policy.get_stdout_stderr()?;
@@ -88,6 +142,14 @@ fn run_command_and_measure_common(
 
     if let Some(value) = iteration.to_env_var_value() {
         command.env("HYPERFINE_ITERATION", value);
+    }
+
+    // Set CPU affinity and scheduling policy in child process before exec
+    #[cfg(target_os = "linux")]
+    if cpu_affinity.is_some() || scheduling_priority.is_some() {
+        unsafe {
+            command.pre_exec(setup_process_priority(cpu_affinity, scheduling_priority));
+        }
     }
 
     let result = execute_and_measure(command, until_text)
@@ -140,11 +202,14 @@ impl Executor for RawExecutor<'_> {
             &self.options.command_input_policy,
             output_policy,
             &command.get_command_line(),
+            self.options.cpu_affinity,
+            self.options.scheduling_priority,
         )?;
 
         Ok((
             TimingResult {
                 time_real: result.time_real,
+                time_real_full: result.time_real_full,
                 time_user: result.time_user,
                 time_system: result.time_system,
                 memory_usage_byte: result.memory_usage_byte,
@@ -205,11 +270,14 @@ impl Executor for ShellExecutor<'_> {
             &self.options.command_input_policy,
             output_policy,
             &command.get_command_line(),
+            self.options.cpu_affinity,
+            self.options.scheduling_priority,
         )?;
 
         // Subtract shell spawning time
         if let Some(spawning_time) = self.shell_spawning_time {
             result.time_real = (result.time_real - spawning_time.time_real).max(0.0);
+            result.time_real_full = (result.time_real_full - spawning_time.time_real_full).max(0.0);
             result.time_user = (result.time_user - spawning_time.time_user).max(0.0);
             result.time_system = (result.time_system - spawning_time.time_system).max(0.0);
         }
@@ -217,6 +285,7 @@ impl Executor for ShellExecutor<'_> {
         Ok((
             TimingResult {
                 time_real: result.time_real,
+                time_real_full: result.time_real_full,
                 time_user: result.time_user,
                 time_system: result.time_system,
                 memory_usage_byte: result.memory_usage_byte,
@@ -280,8 +349,10 @@ impl Executor for ShellExecutor<'_> {
             bar.finish_and_clear()
         }
 
+        let mean_time_real = mean(&times_real);
         self.shell_spawning_time = Some(TimingResult {
-            time_real: mean(&times_real),
+            time_real: mean_time_real,
+            time_real_full: mean_time_real,
             time_user: mean(&times_user),
             time_system: mean(&times_system),
             memory_usage_byte: 0,
@@ -335,9 +406,11 @@ impl Executor for MockExecutor {
             ExitStatus::from_raw(0)
         };
 
+        let time_real = Self::extract_time(command.get_command_line());
         Ok((
             TimingResult {
-                time_real: Self::extract_time(command.get_command_line()),
+                time_real,
+                time_real_full: time_real,
                 time_user: 0.0,
                 time_system: 0.0,
                 memory_usage_byte: 0,

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -12,9 +12,9 @@ use crate::options::{
     CmdFailureAction, CommandOutputPolicy, ExecutorKind, Options, OutputStyleOption,
 };
 use crate::outlier_detection::{modified_zscores, OUTLIER_THRESHOLD};
-use crate::output::format::{format_duration, format_duration_unit};
+use crate::output::format::{format_duration, format_duration_unit, format_memory_value};
 use crate::output::progress_bar::get_progress_bar;
-use crate::output::warnings::{OutlierWarningOptions, Warnings};
+use crate::output::warnings::{OffCpuSeverity, OutlierWarningOptions, Warnings};
 use crate::parameter::ParameterNameAndValue;
 use crate::util::exit_code::extract_exit_code;
 use crate::util::min_max::{max, min};
@@ -30,6 +30,15 @@ use self::executor::Executor;
 
 /// Threshold for warning about fast execution time
 pub const MIN_EXECUTION_TIME: Second = 5e-3;
+
+/// Minimum wall time (in seconds) before off-CPU warnings are considered.
+/// Below this, timing resolution makes ratio calculations unreliable.
+const OFF_CPU_WARNING_MIN_WALL_TIME: Second = 0.005; // 5ms
+
+/// Ratio thresholds for off-CPU time warnings (wall time / CPU time)
+const OFF_CPU_RATIO_NOTE: f64 = 2.0; // 2× triggers a note
+const OFF_CPU_RATIO_WARNING: f64 = 3.0; // 3× triggers a warning
+const OFF_CPU_RATIO_SEVERE: f64 = 5.0; // 5× triggers severe warning
 
 pub struct Benchmark<'a> {
     number: usize,
@@ -257,8 +266,9 @@ impl<'a> Benchmark<'a> {
             conclusion_result.map_or(0.0, |res| res.time_real + self.executor.time_overhead());
 
         // Determine number of benchmark runs
+        // Use time_real_full (includes fork overhead) for scheduling purposes
         let runs_in_min_time = (self.options.min_benchmarking_time
-            / (res.time_real
+            / (res.time_real_full
                 + self.executor.time_overhead()
                 + preparation_overhead
                 + conclusion_overhead)) as u64;
@@ -348,6 +358,15 @@ impl<'a> Benchmark<'a> {
         let user_mean = mean(&times_user);
         let system_mean = mean(&times_system);
 
+        // Compute memory usage statistics (filter out zero values for platforms that don't support it)
+        let memory_values: Vec<u64> = memory_usage_byte
+            .iter()
+            .copied()
+            .filter(|&m| m > 0)
+            .collect();
+        let memory_min = memory_values.iter().copied().min();
+        let memory_max = memory_values.iter().copied().max();
+
         // Formatting and console output
         let (mean_str, time_unit) = format_duration_unit(t_mean, self.options.time_unit);
         let min_str = format_duration(t_min, Some(time_unit));
@@ -389,6 +408,25 @@ impl<'a> Benchmark<'a> {
                     num_str.dimmed()
                 );
             }
+
+            // Display memory usage if available (> 0)
+            if let (Some(mem_min), Some(mem_max)) = (memory_min, memory_max) {
+                if mem_min == mem_max {
+                    // All runs used the same amount of memory
+                    println!(
+                        "  Memory:              {}",
+                        format_memory_value(mem_max, Some(8)).yellow()
+                    );
+                } else {
+                    println!(
+                        "  Memory ({} … {}):   {} … {}",
+                        "min".cyan(),
+                        "max".purple(),
+                        format_memory_value(mem_min, Some(8)).cyan(),
+                        format_memory_value(mem_max, Some(8)).purple()
+                    );
+                }
+            }
         }
 
         // Warnings
@@ -429,6 +467,30 @@ impl<'a> Benchmark<'a> {
             warnings.push(Warnings::OutliersDetected(outlier_warning_options));
         }
 
+        // Check for significant off-CPU time (wall time >> user + system time)
+        let cpu_time = user_mean + system_mean;
+        if t_mean >= OFF_CPU_WARNING_MIN_WALL_TIME && cpu_time > 0.0 {
+            let ratio = t_mean / cpu_time;
+            let severity = if ratio >= OFF_CPU_RATIO_SEVERE {
+                Some(OffCpuSeverity::Severe)
+            } else if ratio >= OFF_CPU_RATIO_WARNING {
+                Some(OffCpuSeverity::Warning)
+            } else if ratio >= OFF_CPU_RATIO_NOTE {
+                Some(OffCpuSeverity::Note)
+            } else {
+                None
+            };
+
+            if let Some(severity) = severity {
+                warnings.push(Warnings::OffCpuTimeDetected {
+                    wall_time: t_mean,
+                    cpu_time,
+                    ratio,
+                    severity,
+                });
+            }
+        }
+
         if !warnings.is_empty() {
             eprintln!(" ");
 
@@ -455,6 +517,8 @@ impl<'a> Benchmark<'a> {
             max: t_max,
             times: Some(times_real),
             memory_usage_byte: Some(memory_usage_byte),
+            memory_min,
+            memory_max,
             exit_codes,
             parameters: self
                 .command

--- a/src/benchmark/relative_speed.rs
+++ b/src/benchmark/relative_speed.rs
@@ -134,6 +134,8 @@ fn create_result(name: &str, mean: Scalar) -> BenchmarkResult {
         max: mean,
         times: None,
         memory_usage_byte: None,
+        memory_min: None,
+        memory_max: None,
         exit_codes: Vec::new(),
         parameters: BTreeMap::new(),
     }

--- a/src/benchmark/timing_result.rs
+++ b/src/benchmark/timing_result.rs
@@ -3,8 +3,11 @@ use crate::util::units::Second;
 /// Results from timing a single command
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TimingResult {
-    /// Wall clock time
+    /// Wall clock time (post-exec on Linux, for reporting)
     pub time_real: Second,
+
+    /// Full wall clock time including fork overhead (for scheduling)
+    pub time_real_full: Second,
 
     /// Time spent in user mode
     pub time_user: Second,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,7 +326,7 @@ fn build_command() -> Command {
         .arg(
             Arg::new("output")
                 .long("output")
-                .conflicts_with("show-output")
+                .conflicts_with_all(["show-output", "until"])
                 .action(ArgAction::Append)
                 .value_name("WHERE")
                 .help(
@@ -349,6 +349,16 @@ fn build_command() -> Command {
                     you can use a shell redirection and the '$HYPERFINE_ITERATION' environment variable:\n    \
                     hyperfine 'my-command > output-${HYPERFINE_ITERATION}.log'\n\n",
                 ),
+        )
+        .arg(
+            Arg::new("until")
+                .long("until")
+                .action(ArgAction::Set)
+                .conflicts_with_all(["show-output", "output"])
+                .help(
+                    "Run the command until it prints the given output in stdout"
+                ),
+
         )
         .arg(
             Arg::new("input")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -402,6 +402,35 @@ fn build_command() -> Command {
             .hide(true)
             .help("Enable debug mode which does not actually run commands, but returns fake times when the command is 'sleep <time>'.")
         )
+        .arg(
+            Arg::new("cpu")
+            .long("cpu")
+            .action(ArgAction::Set)
+            .value_name("CPU")
+            .help("Pin the benchmarked command to a specific CPU core (Linux only). \
+                   This uses sched_setaffinity to set CPU affinity before exec.")
+        )
+        .arg(
+            Arg::new("priority")
+            .long("priority")
+            .action(ArgAction::Set)
+            .value_name("POLICY")
+            .value_parser(["realtime", "idle"])
+            .help("Set the scheduling priority of the benchmarked command (Linux only). \
+                   'realtime' uses SCHED_FIFO with priority 99 for minimal scheduler noise. \
+                   'idle' uses SCHED_IDLE for background execution. \
+                   Note: 'realtime' requires CAP_SYS_NICE capability or root.")
+        )
+        .arg(
+            Arg::new("command-suffix")
+            .last(true)
+            .action(ArgAction::Append)
+            .value_name("ARGS")
+            .help("Arguments to append to each command. Everything after '--' will be \
+                   appended to each benchmarked command.\n\n  \
+                   Example: hyperfine 'gcc -O2 main.c' 'clang -O2 main.c' -- -o /dev/null\n\n\
+                   This runs 'gcc -O2 main.c -o /dev/null' and 'clang -O2 main.c -o /dev/null'.")
+        )
 }
 
 #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -134,30 +134,58 @@ impl<'a> Command<'a> {
 pub struct Commands<'a>(Vec<Command<'a>>);
 
 impl<'a> Commands<'a> {
-    pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands<'a>> {
-        let command_names = matches.get_many::<String>("command-name");
-        let command_strings = matches
+    pub fn from_cli_arguments(matches: &'a ArgMatches) -> Result<Commands<'static>> {
+        // Get the command suffix (everything after --)
+        let command_suffix: String = matches
+            .get_many::<String>("command-suffix")
+            .map(|args| {
+                args.map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .unwrap_or_default();
+
+        // Build command strings, appending suffix if present
+        let command_strings: Vec<&'static str> = matches
             .get_many::<String>("command")
             .unwrap_or_default()
-            .map(|v| v.as_str())
-            .collect::<Vec<_>>();
+            .map(|v| {
+                let s = if command_suffix.is_empty() {
+                    v.clone()
+                } else {
+                    format!("{} {}", v, command_suffix)
+                };
+                // Leak the strings to get 'static lifetime (simple approach as requested)
+                &*Box::leak(s.into_boxed_str())
+            })
+            .collect();
+
+        // Also leak command names for consistent 'static lifetime
+        let command_names: Vec<&'static str> = matches
+            .get_many::<String>("command-name")
+            .map(|names| {
+                names
+                    .map(|v| -> &'static str { &*Box::leak(v.clone().into_boxed_str()) })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         if let Some(args) = matches.get_many::<String>("parameter-scan") {
             let step_size = matches
                 .get_one::<String>("parameter-step-size")
                 .map(|s| s.as_str());
-            Ok(Self(Self::get_parameter_scan_commands(
+            Ok(Commands(Self::get_parameter_scan_commands_static(
                 command_names,
                 command_strings,
                 args,
                 step_size,
             )?))
         } else if let Some(args) = matches.get_many::<String>("parameter-list") {
-            let command_names = command_names.map_or(vec![], |names| {
-                names.map(|v| v.as_str()).collect::<Vec<_>>()
-            });
-            let args: Vec<_> = args.map(|v| v.as_str()).collect::<Vec<_>>();
-            let param_names_and_values: Vec<(&str, Vec<String>)> = args
+            // Leak parameter names to get 'static lifetime
+            let args: Vec<&'static str> = args
+                .map(|v| -> &'static str { &*Box::leak(v.clone().into_boxed_str()) })
+                .collect();
+            let param_names_and_values: Vec<(&'static str, Vec<String>)> = args
                 .chunks_exact(2)
                 .map(|pair| {
                     let name = pair[0];
@@ -182,7 +210,7 @@ impl<'a> Commands<'a> {
                 .collect();
             let param_space_size = dimensions.iter().product();
             if param_space_size == 0 {
-                return Ok(Self(Vec::new()));
+                return Ok(Commands(Vec::new()));
             }
 
             // `--command-name` should appear exactly once or exactly B times,
@@ -230,11 +258,8 @@ impl<'a> Commands<'a> {
                 break 'outer;
             }
 
-            Ok(Self(commands))
+            Ok(Commands(commands))
         } else {
-            let command_names = command_names.map_or(vec![], |names| {
-                names.map(|v| v.as_str()).collect::<Vec<_>>()
-            });
             if command_names.len() > command_strings.len() {
                 return Err(OptionsError::TooManyCommandNames(command_strings.len()).into());
             }
@@ -243,7 +268,7 @@ impl<'a> Commands<'a> {
             for (i, s) in command_strings.iter().enumerate() {
                 commands.push(Command::new(command_names.get(i).copied(), s));
             }
-            Ok(Self(commands))
+            Ok(Commands(commands))
         }
     }
 
@@ -318,6 +343,54 @@ impl<'a> Commands<'a> {
             names.map(|v| v.as_str()).collect::<Vec<_>>()
         });
         let param_name = vals.next().unwrap().as_str();
+        let param_min = vals.next().unwrap().as_str();
+        let param_max = vals.next().unwrap().as_str();
+
+        // attempt to parse as integers
+        if let (Ok(param_min), Ok(param_max), Ok(step)) = (
+            param_min.parse::<i32>(),
+            param_max.parse::<i32>(),
+            step.unwrap_or("1").parse::<i32>(),
+        ) {
+            return Self::build_parameter_scan_commands(
+                param_name,
+                param_min,
+                param_max,
+                step,
+                command_names,
+                command_strings,
+            );
+        }
+
+        // try parsing them as decimals
+        let param_min = Decimal::from_str(param_min)?;
+        let param_max = Decimal::from_str(param_max)?;
+
+        if step.is_none() {
+            return Err(ParameterScanError::StepRequired);
+        }
+
+        let step = Decimal::from_str(step.unwrap())?;
+        Self::build_parameter_scan_commands(
+            param_name,
+            param_min,
+            param_max,
+            step,
+            command_names,
+            command_strings,
+        )
+    }
+
+    /// Version of get_parameter_scan_commands that works with 'static lifetimes
+    fn get_parameter_scan_commands_static(
+        command_names: Vec<&'static str>,
+        command_strings: Vec<&'static str>,
+        mut vals: ValuesRef<'_, String>,
+        step: Option<&str>,
+    ) -> Result<Vec<Command<'static>>, ParameterScanError> {
+        // Leak the parameter name to get 'static lifetime
+        let param_name: &'static str =
+            &*Box::leak(vals.next().unwrap().clone().into_boxed_str());
         let param_min = vals.next().unwrap().as_str();
         let param_max = vals.next().unwrap().as_str();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,4 +55,15 @@ pub enum OptionsError<'a> {
     UnknownOutputPolicy(String),
     #[error("The file '{0}' specified as '--input' does not exist")]
     StdinDataFileDoesNotExist(String),
+    #[error("CPU {0} is out of range. This system has {1} CPUs (0-{2})")]
+    CpuOutOfRange(usize, usize, usize),
+    #[error(
+        "Permission denied for realtime scheduling. \
+         Try: sudo setcap cap_sys_nice+ep $(which hyperfine)"
+    )]
+    RealtimePermissionDenied,
+    #[error("--cpu is only supported on Linux")]
+    CpuAffinityNotSupported,
+    #[error("--priority is only supported on Linux")]
+    SchedulingPriorityNotSupported,
 }

--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -24,7 +24,16 @@ impl Exporter for CsvExporter {
         {
             let mut headers: Vec<Cow<[u8]>> = [
                 // The list of times and exit codes cannot be exported to the CSV file - omit them.
-                "command", "mean", "stddev", "median", "user", "system", "min", "max",
+                "command",
+                "mean",
+                "stddev",
+                "median",
+                "user",
+                "system",
+                "min",
+                "max",
+                "memory_min",
+                "memory_max",
             ]
             .iter()
             .map(|x| Cow::Borrowed(x.as_bytes()))
@@ -50,6 +59,19 @@ impl Exporter for CsvExporter {
             ] {
                 fields.push(Cow::Owned(f.to_string().into_bytes()))
             }
+            // Add memory_min and memory_max (empty string if not available)
+            fields.push(Cow::Owned(
+                res.memory_min
+                    .map(|m| m.to_string())
+                    .unwrap_or_default()
+                    .into_bytes(),
+            ));
+            fields.push(Cow::Owned(
+                res.memory_max
+                    .map(|m| m.to_string())
+                    .unwrap_or_default()
+                    .into_bytes(),
+            ));
             for v in res.parameters.values() {
                 fields.push(Cow::Borrowed(v.as_bytes()))
             }
@@ -78,6 +100,8 @@ fn test_csv() {
             max: 6.0,
             times: Some(vec![7.0, 8.0, 9.0]),
             memory_usage_byte: None,
+            memory_min: Some(1000000), // ~1 MB
+            memory_max: Some(1048576), // 1 MB
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: {
                 let mut params = BTreeMap::new();
@@ -98,6 +122,8 @@ fn test_csv() {
             max: 16.5,
             times: Some(vec![17.0, 18.0, 19.0]),
             memory_usage_byte: None,
+            memory_min: Some(2000000), // ~2 MB
+            memory_max: Some(2097152), // 2 MB
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: {
                 let mut params = BTreeMap::new();
@@ -116,8 +142,8 @@ fn test_csv() {
     .unwrap();
 
     insta::assert_snapshot!(actual, @r#"
-    command,mean,stddev,median,user,system,min,max,parameter_bar,parameter_foo
-    command_a,1,2,1,3,4,5,6,two,one
-    command_b,11,12,11,13,14,15,16.5,seven,one
+    command,mean,stddev,median,user,system,min,max,memory_min,memory_max,parameter_bar,parameter_foo
+    command_a,1,2,1,3,4,5,6,1000000,1048576,two,one
+    command_b,11,12,11,13,14,15,16.5,2000000,2097152,seven,one
     "#);
 }

--- a/src/export/markup.rs
+++ b/src/export/markup.rs
@@ -1,7 +1,7 @@
 use crate::benchmark::relative_speed::BenchmarkResultWithRelativeSpeed;
 use crate::benchmark::{benchmark_result::BenchmarkResult, relative_speed};
 use crate::options::SortOrder;
-use crate::output::format::format_duration_value;
+use crate::output::format::{format_duration_value, format_memory};
 use crate::util::units::Unit;
 
 use super::Exporter;
@@ -17,26 +17,55 @@ pub trait MarkupExporter {
         // prepare table header strings
         let notation = format!("[{}]", unit.short_name());
 
+        // Check if any entry has memory data
+        let has_memory_data = entries
+            .iter()
+            .any(|e| e.result.memory_max.map(|m| m > 0).unwrap_or(false));
+
         // prepare table cells alignment
-        let cells_alignment = [
-            Alignment::Left,
-            Alignment::Right,
-            Alignment::Right,
-            Alignment::Right,
-            Alignment::Right,
-        ];
+        let cells_alignment: Vec<Alignment> = if has_memory_data {
+            vec![
+                Alignment::Left,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Right,
+            ]
+        } else {
+            vec![
+                Alignment::Left,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Right,
+            ]
+        };
 
         // emit table header format
         let mut table = self.table_header(&cells_alignment);
 
         // emit table header data
-        table.push_str(&self.table_row(&[
-            "Command",
-            &format!("Mean {notation}"),
-            &format!("Min {notation}"),
-            &format!("Max {notation}"),
-            "Relative",
-        ]));
+        let header_row: Vec<String> = if has_memory_data {
+            vec![
+                "Command".to_string(),
+                format!("Mean {notation}"),
+                format!("Min {notation}"),
+                format!("Max {notation}"),
+                "Memory".to_string(),
+                "Relative".to_string(),
+            ]
+        } else {
+            vec![
+                "Command".to_string(),
+                format!("Mean {notation}"),
+                format!("Min {notation}"),
+                format!("Max {notation}"),
+                "Relative".to_string(),
+            ]
+        };
+        let header_refs: Vec<&str> = header_row.iter().map(|s| s.as_str()).collect();
+        table.push_str(&self.table_row(&header_refs));
 
         // emit horizontal line
         table.push_str(&self.table_divider(&cells_alignment));
@@ -55,6 +84,16 @@ pub trait MarkupExporter {
             };
             let min_str = format_duration_value(measurement.min, Some(unit)).0;
             let max_str = format_duration_value(measurement.max, Some(unit)).0;
+            let memory_str = match (measurement.memory_min, measurement.memory_max) {
+                (Some(mem_min), Some(mem_max)) if mem_min > 0 && mem_max > 0 => {
+                    if mem_min == mem_max {
+                        format_memory(mem_max)
+                    } else {
+                        format!("{} … {}", format_memory(mem_min), format_memory(mem_max))
+                    }
+                }
+                _ => String::new(),
+            };
             let rel_str = format!("{:.2}", entry.relative_speed);
             let rel_stddev_str = if entry.is_reference {
                 "".into()
@@ -65,13 +104,26 @@ pub trait MarkupExporter {
             };
 
             // prepare table row entries
-            table.push_str(&self.table_row(&[
-                &self.command(&cmd_str),
-                &format!("{mean_str}{stddev_str}"),
-                &min_str,
-                &max_str,
-                &format!("{rel_str}{rel_stddev_str}"),
-            ]))
+            let row: Vec<String> = if has_memory_data {
+                vec![
+                    self.command(&cmd_str),
+                    format!("{mean_str}{stddev_str}"),
+                    min_str,
+                    max_str,
+                    memory_str,
+                    format!("{rel_str}{rel_stddev_str}"),
+                ]
+            } else {
+                vec![
+                    self.command(&cmd_str),
+                    format!("{mean_str}{stddev_str}"),
+                    min_str,
+                    max_str,
+                    format!("{rel_str}{rel_stddev_str}"),
+                ]
+            };
+            let row_refs: Vec<&str> = row.iter().map(|s| s.as_str()).collect();
+            table.push_str(&self.table_row(&row_refs));
         }
 
         // emit table footer format

--- a/src/export/tests.rs
+++ b/src/export/tests.rs
@@ -36,6 +36,8 @@ fn test_markup_export_auto_ms() {
             max: 0.1080,
             times: Some(vec![0.1, 0.1, 0.1]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -51,6 +53,8 @@ fn test_markup_export_auto_ms() {
             max: 2.0080,
             times: Some(vec![2.0, 2.0, 2.0]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -111,6 +115,8 @@ fn test_markup_export_auto_s() {
             max: 2.0080,
             times: Some(vec![2.0, 2.0, 2.0]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -126,6 +132,8 @@ fn test_markup_export_auto_s() {
             max: 0.1080,
             times: Some(vec![0.1, 0.1, 0.1]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -186,6 +194,8 @@ fn test_markup_export_manual_ms() {
             max: 2.0080,
             times: Some(vec![2.0, 2.0, 2.0]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -201,6 +211,8 @@ fn test_markup_export_manual_ms() {
             max: 0.1080,
             times: Some(vec![0.1, 0.1, 0.1]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -260,6 +272,8 @@ fn test_markup_export_manual_s() {
             max: 2.0080,
             times: Some(vec![2.0, 2.0, 2.0]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -275,6 +289,8 @@ fn test_markup_export_manual_s() {
             max: 0.1080,
             times: Some(vec![0.1, 0.1, 0.1]),
             memory_usage_byte: None,
+            memory_min: None,
+            memory_max: None,
             exit_codes: vec![Some(0), Some(0), Some(0)],
             parameters: BTreeMap::new(),
         },
@@ -315,5 +331,53 @@ fn test_markup_export_manual_s() {
     | 0.108 
     | 1.00 
     |===
+    "#);
+}
+
+/// Tests that the markup exports include Peak RSS column when memory data is available
+#[test]
+fn test_markup_export_with_memory() {
+    let results = [
+        BenchmarkResult {
+            command: String::from("sleep 0.1"),
+            command_with_unused_parameters: String::from("sleep 0.1"),
+            mean: 0.1057,
+            stddev: Some(0.0016),
+            median: 0.1057,
+            user: 0.0009,
+            system: 0.0011,
+            min: 0.1023,
+            max: 0.1080,
+            times: Some(vec![0.1, 0.1, 0.1]),
+            memory_usage_byte: None,
+            memory_min: Some(44_564_480), // 42.5 MB
+            memory_max: Some(44_564_480), // 42.5 MB
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::new(),
+        },
+        BenchmarkResult {
+            command: String::from("sleep 2"),
+            command_with_unused_parameters: String::from("sleep 2"),
+            mean: 2.0050,
+            stddev: Some(0.0020),
+            median: 2.0050,
+            user: 0.0009,
+            system: 0.0012,
+            min: 2.0020,
+            max: 2.0080,
+            times: Some(vec![2.0, 2.0, 2.0]),
+            memory_usage_byte: None,
+            memory_min: Some(104_857_600), // 100 MB
+            memory_max: Some(104_857_600), // 100 MB
+            exit_codes: vec![Some(0), Some(0), Some(0)],
+            parameters: BTreeMap::new(),
+        },
+    ];
+
+    insta::assert_snapshot!(get_output::<MarkdownExporter>(&results, None, SortOrder::Command), @r#"
+    | Command | Mean [ms] | Min [ms] | Max [ms] | Memory | Relative |
+    |:---|---:|---:|---:|---:|---:|
+    | `sleep 0.1` | 105.7 ± 1.6 | 102.3 | 108.0 | 42.5 MB | 1.00 |
+    | `sleep 2` | 2005.0 ± 2.0 | 2002.0 | 2008.0 | 100.0 MB | 18.97 ± 0.29 |
     "#);
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -156,6 +156,9 @@ pub enum CommandOutputPolicy {
 
     /// Show command output on the terminal
     Inherit,
+
+    /// Read until the given text is matched and then exit.
+    Until(Vec<u8>),
 }
 
 impl CommandOutputPolicy {
@@ -172,9 +175,19 @@ impl CommandOutputPolicy {
             }
 
             CommandOutputPolicy::Inherit => (Stdio::inherit(), Stdio::inherit()),
+
+            CommandOutputPolicy::Until(_) => (Stdio::piped(), Stdio::null()),
         };
 
         Ok(streams)
+    }
+
+    pub fn get_until_text(&self) -> Option<&[u8]> {
+        if let CommandOutputPolicy::Until(v) = self {
+            Some(v.as_slice())
+        } else {
+            None
+        }
     }
 }
 
@@ -341,6 +354,8 @@ impl Options {
                 policies.push(policy);
             }
             policies
+        } else if let Some(text) = matches.get_one::<String>("until") {
+            vec![CommandOutputPolicy::Until(text.as_bytes().to_vec())]
         } else {
             vec![CommandOutputPolicy::Null]
         };

--- a/src/options.rs
+++ b/src/options.rs
@@ -253,6 +253,21 @@ pub struct Options {
 
     /// Which time unit to use when displaying results
     pub time_unit: Option<Unit>,
+
+    /// CPU core to pin benchmarked commands to (Linux only)
+    pub cpu_affinity: Option<usize>,
+
+    /// Scheduling priority policy (Linux only)
+    pub scheduling_priority: Option<SchedulingPolicy>,
+}
+
+/// Scheduling policy for benchmarked commands
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchedulingPolicy {
+    /// SCHED_FIFO with priority 99 - minimal scheduler interruption
+    Realtime,
+    /// SCHED_IDLE - run only when system is idle
+    Idle,
 }
 
 impl Default for Options {
@@ -274,6 +289,8 @@ impl Default for Options {
             command_output_policies: vec![CommandOutputPolicy::Null],
             time_unit: None,
             command_input_policy: CommandInputPolicy::Null,
+            cpu_affinity: None,
+            scheduling_priority: None,
         }
     }
 }
@@ -456,6 +473,62 @@ impl Options {
         } else {
             CommandInputPolicy::Null
         };
+
+        options.cpu_affinity = matches
+            .get_one::<String>("cpu")
+            .map(|s| {
+                s.parse::<usize>()
+                    .map_err(|e| OptionsError::IntParsingError("cpu", e))
+            })
+            .transpose()?;
+
+        options.scheduling_priority = match matches.get_one::<String>("priority").map(|s| s.as_str()) {
+            Some("realtime") => Some(SchedulingPolicy::Realtime),
+            Some("idle") => Some(SchedulingPolicy::Idle),
+            _ => None,
+        };
+
+        // Validate CPU affinity and scheduling options early
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(cpu) = options.cpu_affinity {
+                let num_cpus = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+                if num_cpus > 0 && cpu >= num_cpus as usize {
+                    return Err(OptionsError::CpuOutOfRange(
+                        cpu,
+                        num_cpus as usize,
+                        num_cpus as usize - 1,
+                    ));
+                }
+            }
+
+            if options.scheduling_priority == Some(SchedulingPolicy::Realtime) {
+                // Check if we have CAP_SYS_NICE capability
+                unsafe {
+                    let param = libc::sched_param { sched_priority: 99 };
+                    if libc::sched_setscheduler(0, libc::SCHED_FIFO, &param) != 0 {
+                        let err = std::io::Error::last_os_error();
+                        if err.raw_os_error() == Some(libc::EPERM) {
+                            return Err(OptionsError::RealtimePermissionDenied);
+                        }
+                    } else {
+                        // Reset to normal scheduler
+                        let param = libc::sched_param { sched_priority: 0 };
+                        libc::sched_setscheduler(0, libc::SCHED_OTHER, &param);
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            if options.cpu_affinity.is_some() {
+                return Err(OptionsError::CpuAffinityNotSupported);
+            }
+            if options.scheduling_priority.is_some() {
+                return Err(OptionsError::SchedulingPriorityNotSupported);
+            }
+        }
 
         Ok(options)
     }

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -1,5 +1,69 @@
 use crate::util::units::{Second, Unit};
 
+/// Unit for memory formatting
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MemoryUnit {
+    Byte,
+    KiloByte,
+    MegaByte,
+    GigaByte,
+}
+
+impl MemoryUnit {
+    fn short_name(&self) -> &'static str {
+        match self {
+            MemoryUnit::Byte => "B",
+            MemoryUnit::KiloByte => "KB",
+            MemoryUnit::MegaByte => "MB",
+            MemoryUnit::GigaByte => "GB",
+        }
+    }
+
+    fn bytes_per_unit(&self) -> f64 {
+        match self {
+            MemoryUnit::Byte => 1.0,
+            MemoryUnit::KiloByte => 1024.0,
+            MemoryUnit::MegaByte => 1024.0 * 1024.0,
+            MemoryUnit::GigaByte => 1024.0 * 1024.0 * 1024.0,
+        }
+    }
+}
+
+/// Format memory size in bytes to a human-readable string with automatic unit selection.
+pub fn format_memory(bytes: u64) -> String {
+    format_memory_value(bytes, None)
+}
+
+/// Format memory size with optional right-padding to specified width.
+pub fn format_memory_value(bytes: u64, width: Option<usize>) -> String {
+    let bytes_f = bytes as f64;
+
+    let (value, unit) = if bytes_f >= MemoryUnit::GigaByte.bytes_per_unit() {
+        (
+            bytes_f / MemoryUnit::GigaByte.bytes_per_unit(),
+            MemoryUnit::GigaByte,
+        )
+    } else if bytes_f >= MemoryUnit::MegaByte.bytes_per_unit() {
+        (
+            bytes_f / MemoryUnit::MegaByte.bytes_per_unit(),
+            MemoryUnit::MegaByte,
+        )
+    } else if bytes_f >= MemoryUnit::KiloByte.bytes_per_unit() {
+        (
+            bytes_f / MemoryUnit::KiloByte.bytes_per_unit(),
+            MemoryUnit::KiloByte,
+        )
+    } else {
+        (bytes_f, MemoryUnit::Byte)
+    };
+
+    let formatted = format!("{:.1} {}", value, unit.short_name());
+    match width {
+        Some(w) => format!("{:>width$}", formatted, width = w),
+        None => formatted,
+    }
+}
+
 /// Format the given duration as a string. The output-unit can be enforced by setting `unit` to
 /// `Some(target_unit)`. If `unit` is `None`, it will be determined automatically.
 pub fn format_duration(duration: Second, unit: Option<Unit>) -> String {
@@ -74,4 +138,17 @@ fn test_format_duration_unit_with_unit() {
 
     assert_eq!("1300000.0 µs", out_str);
     assert_eq!(Unit::MicroSecond, out_unit);
+}
+
+#[test]
+fn test_format_memory() {
+    assert_eq!(format_memory(0), "0.0 B");
+    assert_eq!(format_memory(512), "512.0 B");
+    assert_eq!(format_memory(1023), "1023.0 B");
+    assert_eq!(format_memory(1024), "1.0 KB");
+    assert_eq!(format_memory(1536), "1.5 KB");
+    assert_eq!(format_memory(1024 * 1024), "1.0 MB");
+    assert_eq!(format_memory(44_564_480), "42.5 MB");
+    assert_eq!(format_memory(1024 * 1024 * 1024), "1.0 GB");
+    assert_eq!(format_memory(2 * 1024 * 1024 * 1024), "2.0 GB");
 }

--- a/src/output/warnings.rs
+++ b/src/output/warnings.rs
@@ -9,12 +9,29 @@ pub struct OutlierWarningOptions {
     pub prepare_in_use: bool,
 }
 
+/// Severity level for off-CPU time warning
+pub enum OffCpuSeverity {
+    /// Ratio 2-3×: minor off-CPU time
+    Note,
+    /// Ratio 3-5×: substantial off-CPU time
+    Warning,
+    /// Ratio 5×+: process was mostly off-CPU
+    Severe,
+}
+
 /// A list of all possible warnings
 pub enum Warnings {
     FastExecutionTime,
     NonZeroExitCode,
     SlowInitialRun(Second, OutlierWarningOptions),
     OutliersDetected(OutlierWarningOptions),
+    /// Process spent significant time off-CPU (wall time >> user + system time)
+    OffCpuTimeDetected {
+        wall_time: Second,
+        cpu_time: Second,
+        ratio: f64,
+        severity: OffCpuSeverity,
+    },
 }
 
 impl fmt::Display for Warnings {
@@ -64,6 +81,33 @@ impl fmt::Display for Warnings {
                     " It might help to use the '--warmup' or '--prepare' options."
                 }
             ),
+            Warnings::OffCpuTimeDetected { wall_time, cpu_time, ratio, ref severity } => {
+                let wall_str = format_duration(wall_time, None);
+                let cpu_str = format_duration(cpu_time, None);
+
+                match severity {
+                    OffCpuSeverity::Note => write!(
+                        f,
+                        "Some off-CPU time detected: mean wall time ({wall_str}) is {ratio:.1}× \
+                         the CPU time ({cpu_str}). The benchmark may include scheduling or I/O effects."
+                    ),
+                    OffCpuSeverity::Warning => write!(
+                        f,
+                        "Substantial off-CPU time detected: mean wall time ({wall_str}) is {ratio:.1}× \
+                         the CPU time ({cpu_str}). The benchmark is partly measuring system-level effects \
+                         (scheduling, I/O, memory management) rather than program performance. \
+                         Consider investigating with 'perf' or checking for resource contention."
+                    ),
+                    OffCpuSeverity::Severe => write!(
+                        f,
+                        "Process was off-CPU for most of its runtime: mean wall time ({wall_str}) is \
+                         {ratio:.1}× the CPU time ({cpu_str}). This benchmark is likely not measuring \
+                         what you intend. Common causes include: transparent hugepage allocation, \
+                         I/O blocking, memory pressure, or CPU throttling. Consider running on a \
+                         quiet system or investigating the root cause."
+                    ),
+                }
+            }
         }
     }
 }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -12,6 +12,7 @@ use nix::fcntl::{splice, SpliceFFlags};
 use std::fs::File;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsFd;
+use std::os::unix::process::ExitStatusExt;
 
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
@@ -79,8 +80,91 @@ fn discard(output: ChildStdout) {
     }
 }
 
+fn discard_until(output: ChildStdout, ptn: &[u8]) -> Result<bool> {
+    const CHUNK_SIZE: usize = 64 << 10;
+
+    let mut output = output;
+    let mut buf = [0; CHUNK_SIZE];
+
+    let ptn_len = ptn.len();
+    let lps = compute_lps_array(ptn);
+    let mut j = 0; // position of the character in ptn
+    let mut read_more = false;
+
+    loop {
+        let n = output.read(&mut buf)?;
+
+        if n == 0 {
+            return Ok(false);
+        }
+
+        let mut i = 0; // position of the character in buf
+        if read_more && ptn[j] != buf[i] {
+            if j != 0 {
+                j = lps[j - 1];
+            } else {
+                i += 1;
+            }
+        }
+        read_more = false;
+
+        while i < n {
+            if ptn[j] == buf[i] {
+                i += 1;
+                j += 1;
+            }
+
+            if j == ptn_len {
+                return Ok(true);
+            }
+
+            if i == n {
+                read_more = true;
+                break;
+            }
+
+            if ptn[j] == buf[i] {
+                continue;
+            }
+
+            if j != 0 {
+                j = lps[j - 1];
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+#[inline(always)]
+fn compute_lps_array(pattern: &[u8]) -> Vec<usize> {
+    let ptn_len = pattern.len();
+    let mut lps = vec![0; ptn_len];
+
+    // length of the previous longest prefix suffix
+    let mut len = 0;
+    lps[0] = 0;
+
+    // the loop calculates lps[i] for i = 1 to ptn_len-1
+    let mut i = 1;
+    while i < ptn_len {
+        if pattern[i] == pattern[len] {
+            len += 1;
+            lps[i] = len;
+            i += 1;
+        } else if len != 0 {
+            len = lps[len - 1];
+        } else {
+            lps[i] = 0;
+            i += 1;
+        }
+    }
+
+    lps
+}
+
 /// Execute the given command and return a timing summary
-pub fn execute_and_measure(mut command: Command) -> Result<TimerResult> {
+pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result<TimerResult> {
     #[cfg(not(windows))]
     let cpu_timer = self::unix_timer::CPUTimer::start();
 
@@ -100,6 +184,34 @@ pub fn execute_and_measure(mut command: Command) -> Result<TimerResult> {
         // SAFETY: We created a suspended process
         unsafe { self::windows_timer::CPUTimer::start_suspended_process(&child) }
     };
+
+    if let Some(ptn) = until {
+        // Handle CommandOutputPolicy::Until
+        let output = child
+            .stdout
+            .take()
+            .expect("Expected a pipe when until text is present.");
+
+        let status = if discard_until(output, ptn)? {
+            ExitStatus::from_raw(0)
+        } else {
+            ExitStatus::from_raw(-1)
+        };
+
+        let time_real = wallclock_timer.stop();
+        let (time_user, time_system, memory_usage_byte) = cpu_timer.stop();
+
+        child.kill()?;
+        child.wait()?;
+
+        return Ok(TimerResult {
+            time_real,
+            time_user,
+            time_system,
+            memory_usage_byte,
+            status,
+        });
+    }
 
     if let Some(output) = child.stdout.take() {
         // Handle CommandOutputPolicy::Pipe

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -3,19 +3,8 @@ mod wall_clock_timer;
 #[cfg(windows)]
 mod windows_timer;
 
-#[cfg(not(windows))]
+#[cfg(all(unix, not(target_os = "linux")))]
 mod unix_timer;
-
-#[cfg(target_os = "linux")]
-use nix::fcntl::{splice, SpliceFFlags};
-#[cfg(target_os = "linux")]
-use std::fs::File;
-#[cfg(target_os = "linux")]
-use std::os::fd::AsFd;
-use std::os::unix::process::ExitStatusExt;
-
-#[cfg(target_os = "windows")]
-use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
 
 use crate::util::units::Second;
 use wall_clock_timer::WallClockTimer;
@@ -25,7 +14,7 @@ use std::process::{ChildStdout, Command, ExitStatus};
 
 use anyhow::Result;
 
-#[cfg(not(windows))]
+#[cfg(all(unix, not(target_os = "linux")))]
 #[derive(Debug, Copy, Clone)]
 struct CPUTimes {
     /// Total amount of time spent executing in user mode
@@ -41,7 +30,10 @@ struct CPUTimes {
 /// Used to indicate the result of running a command
 #[derive(Debug, Copy, Clone)]
 pub struct TimerResult {
+    /// Wall-clock time of the command execution (post-exec on Linux)
     pub time_real: Second,
+    /// Full wall-clock time including fork overhead (for scheduling purposes)
+    pub time_real_full: Second,
     pub time_user: Second,
     pub time_system: Second,
     pub memory_usage_byte: u64,
@@ -50,26 +42,42 @@ pub struct TimerResult {
 }
 
 /// Discard the output of a child process.
+#[cfg(target_os = "linux")]
 fn discard(output: ChildStdout) {
+    use nix::fcntl::{splice, SpliceFFlags};
+    use std::fs::File;
+    use std::os::fd::AsFd;
+
     const CHUNK_SIZE: usize = 64 << 10;
 
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(file) = File::create("/dev/null") {
-            while let Ok(bytes) = splice(
-                output.as_fd(),
-                None,
-                file.as_fd(),
-                None,
-                CHUNK_SIZE,
-                SpliceFFlags::empty(),
-            ) {
-                if bytes == 0 {
-                    break;
-                }
+    if let Ok(file) = File::create("/dev/null") {
+        while let Ok(bytes) = splice(
+            output.as_fd(),
+            None,
+            file.as_fd(),
+            None,
+            CHUNK_SIZE,
+            SpliceFFlags::empty(),
+        ) {
+            if bytes == 0 {
+                break;
             }
         }
     }
+
+    let mut output = output;
+    let mut buf = [0; CHUNK_SIZE];
+    while let Ok(bytes) = output.read(&mut buf) {
+        if bytes == 0 {
+            break;
+        }
+    }
+}
+
+/// Discard the output of a child process.
+#[cfg(not(target_os = "linux"))]
+fn discard(output: ChildStdout) {
+    const CHUNK_SIZE: usize = 64 << 10;
 
     let mut output = output;
     let mut buf = [0; CHUNK_SIZE];
@@ -163,30 +171,27 @@ fn compute_lps_array(pattern: &[u8]) -> Vec<usize> {
     lps
 }
 
-/// Execute the given command and return a timing summary
+// =============================================================================
+// Windows implementation
+// =============================================================================
+
+#[cfg(windows)]
 pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result<TimerResult> {
-    #[cfg(not(windows))]
-    let cpu_timer = self::unix_timer::CPUTimer::start();
+    use std::os::windows::process::CommandExt;
+    use std::os::windows::process::ExitStatusExt;
+    use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
 
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-
-        // Create the process in a suspended state so that we don't miss any cpu time between process creation and `CPUTimer` start.
-        command.creation_flags(CREATE_SUSPENDED);
-    }
+    // Create the process in a suspended state so that we don't miss any cpu time
+    // between process creation and `CPUTimer` start.
+    command.creation_flags(CREATE_SUSPENDED);
 
     let wallclock_timer = WallClockTimer::start();
     let mut child = command.spawn()?;
 
-    #[cfg(windows)]
-    let cpu_timer = {
-        // SAFETY: We created a suspended process
-        unsafe { self::windows_timer::CPUTimer::start_suspended_process(&child) }
-    };
+    // SAFETY: We created a suspended process
+    let cpu_timer = unsafe { self::windows_timer::CPUTimer::start_suspended_process(&child) };
 
     if let Some(ptn) = until {
-        // Handle CommandOutputPolicy::Until
         let output = child
             .stdout
             .take()
@@ -201,23 +206,12 @@ pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result
         let time_real = wallclock_timer.stop();
         let (time_user, time_system, memory_usage_byte) = cpu_timer.stop();
 
-        #[cfg(unix)]
-        {
-            // child.kill() sends SIGKILL we don't really want that.
-            use nix::sys::signal::{self, Signal};
-            use nix::unistd::Pid;
-            signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM)?;
-        }
-
-        #[cfg(not(unix))]
-        {
-            child.kill()?;
-        }
-
+        child.kill()?;
         child.wait()?;
 
         return Ok(TimerResult {
             time_real,
+            time_real_full: time_real,
             time_user,
             time_system,
             memory_usage_byte,
@@ -226,7 +220,6 @@ pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result
     }
 
     if let Some(output) = child.stdout.take() {
-        // Handle CommandOutputPolicy::Pipe
         discard(output);
     }
 
@@ -237,6 +230,212 @@ pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result
 
     Ok(TimerResult {
         time_real,
+        time_real_full: time_real,
+        time_user,
+        time_system,
+        memory_usage_byte,
+        status,
+    })
+}
+
+// =============================================================================
+// Unix (non-Linux) implementation - macOS, BSD, etc.
+// =============================================================================
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result<TimerResult> {
+    use std::os::unix::process::ExitStatusExt;
+
+    let cpu_timer = self::unix_timer::CPUTimer::start();
+    let wallclock_timer = WallClockTimer::start();
+    let mut child = command.spawn()?;
+
+    if let Some(ptn) = until {
+        let output = child
+            .stdout
+            .take()
+            .expect("Expected a pipe when until text is present.");
+
+        let status = if discard_until(output, ptn)? {
+            ExitStatus::from_raw(0)
+        } else {
+            ExitStatus::from_raw(-1)
+        };
+
+        let time_real = wallclock_timer.stop();
+        let (time_user, time_system, memory_usage_byte) = cpu_timer.stop();
+
+        // child.kill() sends SIGKILL, we don't really want that.
+        use nix::sys::signal::{self, Signal};
+        use nix::unistd::Pid;
+        signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM)?;
+
+        child.wait()?;
+
+        return Ok(TimerResult {
+            time_real,
+            time_real_full: time_real,
+            time_user,
+            time_system,
+            memory_usage_byte,
+            status,
+        });
+    }
+
+    if let Some(output) = child.stdout.take() {
+        discard(output);
+    }
+
+    let status = child.wait()?;
+
+    let time_real = wallclock_timer.stop();
+    let (time_user, time_system, memory_usage_byte) = cpu_timer.stop();
+
+    Ok(TimerResult {
+        time_real,
+        time_real_full: time_real,
+        time_user,
+        time_system,
+        memory_usage_byte,
+        status,
+    })
+}
+
+// =============================================================================
+// Linux implementation - with post-fork timing
+// =============================================================================
+
+/// Wait for a specific child process and get its resource usage.
+/// Unlike `getrusage(RUSAGE_CHILDREN)`, this returns stats for just this child.
+#[cfg(target_os = "linux")]
+fn wait4_child(pid: i32) -> Result<(ExitStatus, libc::rusage)> {
+    use std::mem::MaybeUninit;
+    use std::os::unix::process::ExitStatusExt;
+
+    let mut status: i32 = 0;
+    let mut rusage = MaybeUninit::<libc::rusage>::uninit();
+
+    let result = unsafe { libc::wait4(pid, &mut status, 0, rusage.as_mut_ptr()) };
+
+    if result == -1 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let rusage = unsafe { rusage.assume_init() };
+    let exit_status = ExitStatus::from_raw(status);
+
+    Ok((exit_status, rusage))
+}
+
+/// Extract timing and memory info from rusage.
+#[cfg(target_os = "linux")]
+fn extract_rusage_stats(rusage: &libc::rusage) -> (Second, Second, u64) {
+    const MICROSEC_PER_SEC: i64 = 1_000_000;
+
+    let time_user = (rusage.ru_utime.tv_sec as i64 * MICROSEC_PER_SEC
+        + rusage.ru_utime.tv_usec as i64) as f64
+        * 1e-6;
+
+    let time_system = (rusage.ru_stime.tv_sec as i64 * MICROSEC_PER_SEC
+        + rusage.ru_stime.tv_usec as i64) as f64
+        * 1e-6;
+
+    // Linux returns ru_maxrss in kilobytes
+    let memory_usage_byte = (rusage.ru_maxrss as u64) * 1024;
+
+    (time_user, time_system, memory_usage_byte)
+}
+
+#[cfg(target_os = "linux")]
+pub fn execute_and_measure(mut command: Command, until: Option<&[u8]>) -> Result<TimerResult> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::CommandExt;
+    use std::os::unix::process::ExitStatusExt;
+
+    // Create pipe for child to signal "ready to exec"
+    // O_CLOEXEC ensures the pipe is closed on exec, which signals the parent
+    let (pipe_read, pipe_write) = nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC)?;
+    let pipe_read_fd = pipe_read.as_raw_fd();
+    let pipe_write_fd = pipe_write.as_raw_fd();
+
+    // Set up pre_exec hook to signal readiness (pipe closes on exec due to CLOEXEC)
+    // We need to keep the write end open until exec, then CLOEXEC closes it
+    unsafe {
+        command.pre_exec(move || {
+            // The pipe_write fd will be closed automatically by CLOEXEC when exec happens
+            // We don't need to do anything here - just existing is enough
+            // But we need to reference pipe_write_fd to ensure the fd is inherited
+            let _ = pipe_write_fd;
+            Ok(())
+        });
+    }
+
+    // Start FULL wall clock timer (includes fork overhead, for scheduling)
+    let wallclock_timer_full = WallClockTimer::start();
+
+    // Spawn the child
+    let mut child = command.spawn()?;
+    let pid = child.id() as i32;
+
+    // Close our copy of the write end (drop the OwnedFd)
+    drop(pipe_write);
+
+    // Wait for child to reach exec (pipe closes, read returns 0)
+    let mut buf = [0u8; 1];
+    let _ = nix::unistd::read(pipe_read_fd, &mut buf); // Blocks until pipe closes (exec) or child dies
+    drop(pipe_read);
+
+    // Start POST-EXEC wall clock timer (excludes fork overhead, for reporting)
+    let wallclock_timer = WallClockTimer::start();
+
+    if let Some(ptn) = until {
+        let output = child
+            .stdout
+            .take()
+            .expect("Expected a pipe when until text is present.");
+
+        let matched = discard_until(output, ptn)?;
+        let time_real = wallclock_timer.stop();
+        let time_real_full = wallclock_timer_full.stop();
+
+        // child.kill() sends SIGKILL, we don't really want that.
+        use nix::sys::signal::{self, Signal};
+        use nix::unistd::Pid;
+        signal::kill(Pid::from_raw(pid), Signal::SIGTERM)?;
+
+        // Use wait4 to get per-child rusage
+        let (_, rusage) = wait4_child(pid)?;
+        let (time_user, time_system, memory_usage_byte) = extract_rusage_stats(&rusage);
+
+        let status = if matched {
+            ExitStatus::from_raw(0)
+        } else {
+            ExitStatus::from_raw(-1)
+        };
+
+        return Ok(TimerResult {
+            time_real,
+            time_real_full,
+            time_user,
+            time_system,
+            memory_usage_byte,
+            status,
+        });
+    }
+
+    if let Some(output) = child.stdout.take() {
+        discard(output);
+    }
+
+    // Use wait4 to get per-child rusage
+    let (status, rusage) = wait4_child(pid)?;
+    let time_real = wallclock_timer.stop();
+    let time_real_full = wallclock_timer_full.stop();
+    let (time_user, time_system, memory_usage_byte) = extract_rusage_stats(&rusage);
+
+    Ok(TimerResult {
+        time_real,
+        time_real_full,
         time_user,
         time_system,
         memory_usage_byte,

--- a/src/timer/unix_timer.rs
+++ b/src/timer/unix_timer.rs
@@ -1,4 +1,4 @@
-#![cfg(not(windows))]
+#![cfg(all(unix, not(target_os = "linux")))]
 
 use std::convert::TryFrom;
 use std::mem;


### PR DESCRIPTION
Hey, thanks for this project and if this feature doesn't meet the goals of it no hard feelings at all and feel free to close the PR :) - I just personally needed the feature and thought it might not be a bad idea to try to upstream if others also find it useful.

My motivation is that sometimes I need to benchmark a program (and specifically its cold start time) but the program doesn't terminate (think web servers) but just prints a text indicating that it's in a ready state.

For example a next.js app prints a `Ready in ---` text when it's ready, so I use hyperfine with `--until "Ready in"` to get the elapsed time until the program prints that line in the output.

Let me know what you think :)

(p.s I can fix it on non-unix if there is interest in the feature, otherwise I don't need it for myself...)