### PR TITLE
Update ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,9 @@ like `--warmup`, `--prepare <cmd>`, `--setup <cmd>` or `--cleanup <cmd>`:
 
 ### On Ubuntu
 
-Download the appropriate `.deb` package from the [Release page](https://github.com/sharkdp/hyperfine/releases)
-and install it via `dpkg`:
+On Ubuntu, hyperfine can be installed [from the Official Archive](https://launchpad.net/ubuntu/+source/rust-hyperfine):
 ```
-wget https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine_1.19.0_amd64.deb
-sudo dpkg -i hyperfine_1.19.0_amd64.deb
+apt install hyperfine
 ```
 
 ### On Fedora


### PR DESCRIPTION
hyperfine on ubuntu can be installed using apt

https://launchpad.net/ubuntu/+source/rust-hyperfine

latest version packaged is [1.19.0-1](https://launchpad.net/ubuntu/+source/rust-hyperfine/1.19.0-1)