### PR TITLE
Add option to show resource usage

### DIFF
--- a/src/benchmark/executor.rs
+++ b/src/benchmark/executor.rs
@@ -128,15 +128,7 @@ impl Executor for RawExecutor<'_> {
             &command.get_command_line(),
         )?;
 
-        Ok((
-            TimingResult {
-                time_real: result.time_real,
-                time_user: result.time_user,
-                time_system: result.time_system,
-                memory_usage_byte: result.memory_usage_byte,
-            },
-            result.status,
-        ))
+        Ok((result.timing, result.status))
     }
 
     fn calibrate(&mut self) -> Result<()> {
@@ -195,20 +187,13 @@ impl Executor for ShellExecutor<'_> {
 
         // Subtract shell spawning time
         if let Some(spawning_time) = self.shell_spawning_time {
-            result.time_real = (result.time_real - spawning_time.time_real).max(0.0);
-            result.time_user = (result.time_user - spawning_time.time_user).max(0.0);
-            result.time_system = (result.time_system - spawning_time.time_system).max(0.0);
+            result.timing.time_real = (result.timing.time_real - spawning_time.time_real).max(0.0);
+            result.timing.time_user = (result.timing.time_user - spawning_time.time_user).max(0.0);
+            result.timing.time_system =
+                (result.timing.time_system - spawning_time.time_system).max(0.0);
         }
 
-        Ok((
-            TimingResult {
-                time_real: result.time_real,
-                time_user: result.time_user,
-                time_system: result.time_system,
-                memory_usage_byte: result.memory_usage_byte,
-            },
-            result.status,
-        ))
+        Ok((result.timing, result.status))
     }
 
     /// Measure the average shell spawning time
@@ -271,6 +256,12 @@ impl Executor for ShellExecutor<'_> {
             time_user: mean(&times_user),
             time_system: mean(&times_system),
             memory_usage_byte: 0,
+            voluntary_context_switches: 0,
+            context_switches: 0,
+            filesystem_input: 0,
+            filesystem_output: 0,
+            minor_page_faults: 0,
+            major_page_faults: 0,
         });
 
         Ok(())
@@ -327,6 +318,12 @@ impl Executor for MockExecutor {
                 time_user: 0.0,
                 time_system: 0.0,
                 memory_usage_byte: 0,
+                voluntary_context_switches: 0,
+                context_switches: 0,
+                filesystem_input: 0,
+                filesystem_output: 0,
+                minor_page_faults: 0,
+                major_page_faults: 0,
             },
             status,
         ))

--- a/src/benchmark/timing_result.rs
+++ b/src/benchmark/timing_result.rs
@@ -14,4 +14,22 @@ pub struct TimingResult {
 
     /// Maximum amount of memory used, in bytes
     pub memory_usage_byte: u64,
+
+    /// Number of voluntary context switches
+    pub voluntary_context_switches: u64,
+
+    /// Number of involuntary context switches
+    pub context_switches: u64,
+
+    /// Number of times the filesystem had to perform input.
+    pub filesystem_input: u64,
+
+    /// Number of times the filesystem had to perform output.
+    pub filesystem_output: u64,
+
+    /// Number of minor page faults
+    pub minor_page_faults: u64,
+
+    /// Number of major page faults
+    pub major_page_faults: u64,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -238,6 +238,12 @@ fn build_command() -> Command {
                 ),
         )
         .arg(
+            Arg::new("resource-usage")
+            .long("resource-usage")
+            .action(ArgAction::SetTrue)
+            .help("Show resource usage of the command.")
+        )
+        .arg(
             Arg::new("sort")
             .long("sort")
             .action(ArgAction::Set)

--- a/src/options.rs
+++ b/src/options.rs
@@ -223,6 +223,9 @@ pub struct Options {
     /// What color mode to use for the terminal output
     pub output_style: OutputStyleOption,
 
+    /// Display resource usage of commands
+    pub resource_usage: bool,
+
     /// How to order benchmarks in the relative speed comparison
     pub sort_order_speed_comparison: SortOrder,
 
@@ -255,6 +258,7 @@ impl Default for Options {
             setup_command: None,
             cleanup_command: None,
             output_style: OutputStyleOption::Full,
+            resource_usage: false,
             sort_order_speed_comparison: SortOrder::MeanTime,
             sort_order_exports: SortOrder::Command,
             executor_kind: ExecutorKind::default(),
@@ -372,6 +376,8 @@ impl Options {
                 }
             }
         };
+
+        options.resource_usage = *matches.get_one::<bool>("resource-usage").unwrap_or(&false);
 
         match options.output_style {
             OutputStyleOption::Basic | OutputStyleOption::NoColor => {

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::util::units::{Second, Unit};
 
 /// Format the given duration as a string. The output-unit can be enforced by setting `unit` to
@@ -22,6 +24,51 @@ pub fn format_duration_value(duration: Second, unit: Option<Unit>) -> (String, U
         (Unit::MilliSecond.format(duration), Unit::MilliSecond)
     } else {
         (Unit::Second.format(duration), Unit::Second)
+    }
+}
+
+/// Wrapper to format memory sizes as a string.
+pub struct BytesFormat(pub u64);
+
+impl Display for BytesFormat {
+    #[expect(clippy::cast_precision_loss)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let bytes = self.0;
+        if bytes < 100_000 {
+            return write!(f, "{bytes} b");
+        }
+        let bytes = bytes as f64 / 1000.0;
+        if bytes < 10.0 {
+            return write!(f, "{bytes:.3} kb");
+        }
+        if bytes < 100.0 {
+            return write!(f, "{bytes:.2} kb");
+        }
+        if bytes < 1000.0 {
+            return write!(f, "{bytes:.1} kb");
+        }
+        let bytes = bytes / 1000.0;
+        if bytes < 10.0 {
+            return write!(f, "{bytes:.3} MB");
+        }
+        if bytes < 100.0 {
+            return write!(f, "{bytes:.2} MB");
+        }
+        if bytes < 1000.0 {
+            return write!(f, "{bytes:.1} MB");
+        }
+        let bytes = bytes / 1000.0;
+        if bytes < 10.0 {
+            return write!(f, "{bytes:.3} GB");
+        }
+        if bytes < 100.0 {
+            return write!(f, "{bytes:.2} GB");
+        }
+        if bytes < 1000.0 {
+            return write!(f, "{bytes:.1} GB");
+        }
+        let bytes = bytes / 1000.0;
+        write!(f, "{bytes:.0} TB")
     }
 }
 
@@ -74,4 +121,15 @@ fn test_format_duration_unit_with_unit() {
 
     assert_eq!("1300000.0 µs", out_str);
     assert_eq!(Unit::MicroSecond, out_unit);
+}
+
+#[test]
+fn test_format_bytes() {
+    assert_eq!("0 b", format!("{}", BytesFormat(0)));
+    assert_eq!("42 b", format!("{}", BytesFormat(42)));
+    assert_eq!("10240 b", format!("{}", BytesFormat(10240)));
+    assert_eq!("102.4 kb", format!("{}", BytesFormat(102400)));
+    assert_eq!("102.4 MB", format!("{}", BytesFormat(102400000)));
+    assert_eq!("1.024 GB", format!("{}", BytesFormat(1024000000)));
+    assert_eq!("18446744 TB", format!("{}", BytesFormat(u64::MAX)));
 }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -8,6 +8,8 @@ mod unix_timer;
 
 #[cfg(target_os = "linux")]
 use nix::fcntl::{splice, SpliceFFlags};
+use std::convert::TryFrom;
+use std::convert::TryInto;
 #[cfg(target_os = "linux")]
 use std::fs::File;
 #[cfg(target_os = "linux")]
@@ -16,7 +18,7 @@ use std::os::fd::AsFd;
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
 
-use crate::util::units::Second;
+use crate::benchmark::timing_result::TimingResult;
 use wall_clock_timer::WallClockTimer;
 
 use std::io::Read;
@@ -33,17 +35,29 @@ struct CPUTimes {
     /// Total amount of time spent executing in kernel mode
     pub system_usec: i64,
 
-    /// Maximum amount of memory used by the process, in bytes
-    pub memory_usage_byte: u64,
+    /// Number of voluntary context switches
+    pub voluntary_context_switches: u64,
+
+    /// Number of involuntary context switches
+    pub context_switches: u64,
+
+    /// Number of times the filesystem had to perform input.
+    pub filesystem_input: u64,
+
+    /// Number of times the filesystem had to perform output.
+    pub filesystem_output: u64,
+
+    /// Number of minor page faults
+    pub minor_page_faults: u64,
+
+    /// Number of major page faults
+    pub major_page_faults: u64,
 }
 
 /// Used to indicate the result of running a command
 #[derive(Debug, Copy, Clone)]
 pub struct TimerResult {
-    pub time_real: Second,
-    pub time_user: Second,
-    pub time_system: Second,
-    pub memory_usage_byte: u64,
+    pub timing: TimingResult,
     /// The exit status of the process
     pub status: ExitStatus,
 }
@@ -106,16 +120,61 @@ pub fn execute_and_measure(mut command: Command) -> Result<TimerResult> {
         discard(output);
     }
 
-    let status = child.wait()?;
+    #[cfg(not(windows))]
+    let (status, memory_usage_byte) = {
+        use std::io::Error;
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut raw_status = 0;
+        let pid = child.id().try_into().expect("should convert to pid_t");
+        // SAFETY: libc::rusage is Plain Old Data
+        let mut rusage = unsafe { std::mem::zeroed() };
+        // SAFETY: all syscall arguments are valid
+        let result = unsafe { libc::wait4(pid, &raw mut raw_status, 0, &raw mut rusage) };
+        if result != pid {
+            return Err(Error::last_os_error().into());
+        }
+
+        // Linux and *BSD return the value in KibiBytes, Darwin flavors in bytes
+        let max_rss_byte = if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
+            rusage.ru_maxrss
+        } else {
+            rusage.ru_maxrss * 1024
+        };
+        let memory_usage_byte = u64::try_from(max_rss_byte).expect("should not be negative");
+
+        let status = ExitStatus::from_raw(raw_status);
+
+        (status, memory_usage_byte)
+    };
+
+    #[cfg(windows)]
+    let (status, memory_usage_byte) = (child.wait()?, 0);
 
     let time_real = wallclock_timer.stop();
-    let (time_user, time_system, memory_usage_byte) = cpu_timer.stop();
+    let (
+        time_user,
+        time_system,
+        voluntary_context_switches,
+        context_switches,
+        filesystem_input,
+        filesystem_output,
+        minor_page_faults,
+        major_page_faults,
+    ) = cpu_timer.stop();
 
-    Ok(TimerResult {
+    let timing = TimingResult {
         time_real,
         time_user,
         time_system,
         memory_usage_byte,
-        status,
-    })
+        voluntary_context_switches,
+        context_switches,
+        filesystem_input,
+        filesystem_output,
+        minor_page_faults,
+        major_page_faults,
+    };
+
+    Ok(TimerResult { timing, status })
 }

--- a/src/util/min_max.rs
+++ b/src/util/min_max.rs
@@ -14,6 +14,36 @@ pub fn min(vals: &[f64]) -> f64 {
         .unwrap()
 }
 
+pub struct Statistics {
+    pub min: u64,
+    pub max: u64,
+    pub mean: u64,
+    pub median: u64,
+}
+
+/// A function to comupute statistics for u64's
+#[must_use]
+pub fn statistics(vals: &[u64]) -> Statistics {
+    assert!(!vals.is_empty());
+
+    let mut copy = vals.to_vec();
+    assert!(!copy.is_empty());
+    copy.sort_unstable();
+
+    let len = copy.len();
+    // For an even set use the upper middle value, since it is higher than the
+    // lower middle value, and higher most of the time means worse, to get an
+    // actual data sample as result and not an computed average.
+    let median_idx = if len % 2 == 0 { len / 2 + 1 } else { len / 2 };
+
+    Statistics {
+        min: *copy.first().expect("non-empty"),
+        max: *copy.last().expect("non-empty"),
+        mean: copy.iter().sum::<u64>() / len as u64,
+        median: copy[median_idx],
+    }
+}
+
 #[test]
 fn test_max() {
     let assert_float_eq = |a: f64, b: f64| {


### PR DESCRIPTION
Show the information of getrusage(2) returned via wait4(2).

Also get the maximum RSS usage from wait4(2), since getrusage(2) will for the lifetime of the hyperfine process always remember the highest children, not the last one.