### PR TITLE
Add colors to --help/-h

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,10 @@
 use std::ffi::OsString;
 
 use clap::{
-    builder::NonEmptyStringValueParser, crate_version, Arg, ArgAction, ArgMatches, Command,
-    ValueHint,
+    builder::styling::{AnsiColor, Effects},
+    builder::NonEmptyStringValueParser,
+    builder::Styles,
+    crate_version, Arg, ArgAction, ArgMatches, Command, ValueHint,
 };
 
 pub fn get_cli_arguments<'a, I, T>(args: I) -> ArgMatches
@@ -14,10 +16,17 @@ where
     command.get_matches_from(args)
 }
 
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Cyan.on_default());
+
 /// Build the clap command for parsing command line arguments
 fn build_command() -> Command {
     Command::new("hyperfine")
         .version(crate_version!())
+        .styles(STYLES)
         .next_line_help(true)
         .hide_possible_values(true)
         .about("A command-line benchmarking tool.")


### PR DESCRIPTION
User can disable colors via NO_COLOR=1 environment variable if needed

Output of `hyperfine --help`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="779" height="3552" alt="hyperfine-before" src="https://github.com/user-attachments/assets/10f2a74c-c4de-463e-bc80-39ff2665015d" /> | <img width="779" height="3552" alt="hyperfine-colors" src="https://github.com/user-attachments/assets/fd8a55f7-6cde-4e06-bf63-3f1a107147b0" /> | <img width="779" height="3552" alt="hyperfine-no-color" src="https://github.com/user-attachments/assets/27938268-c2db-404e-a523-90cfdb071738" /> |
