### PR TITLE
Export empty CSV columns for reference command parameters

### DIFF
--- a/src/export/csv.rs
+++ b/src/export/csv.rs
@@ -21,6 +21,7 @@ impl Exporter for CsvExporter {
     ) -> Result<Vec<u8>> {
         let mut writer = WriterBuilder::new().from_writer(vec![]);
 
+        let mut num_params = 0;
         {
             let mut headers: Vec<Cow<[u8]>> = [
                 // The list of times and exit codes cannot be exported to the CSV file - omit them.
@@ -29,7 +30,11 @@ impl Exporter for CsvExporter {
             .iter()
             .map(|x| Cow::Borrowed(x.as_bytes()))
             .collect();
-            if let Some(res) = results.first() {
+
+            // Use param column names from the first non-reference command
+            let non_ref = results.iter().find(|res| !res.parameters.is_empty());
+            if let Some(res) = non_ref {
+                num_params = res.parameters.len();
                 for param_name in res.parameters.keys() {
                     headers.push(Cow::Owned(format!("parameter_{param_name}").into_bytes()));
                 }
@@ -50,8 +55,14 @@ impl Exporter for CsvExporter {
             ] {
                 fields.push(Cow::Owned(f.to_string().into_bytes()))
             }
-            for v in res.parameters.values() {
-                fields.push(Cow::Borrowed(v.as_bytes()))
+            if res.parameters.is_empty() && num_params > 0 {
+                // Reference command, insert an empty column for each param
+                let mut empties = vec![Cow::Borrowed("".as_bytes()); num_params];
+                fields.append(&mut empties);
+            } else {
+                for v in res.parameters.values() {
+                    fields.push(Cow::Borrowed(v.as_bytes()))
+                }
             }
             writer.write_record(fields)?;
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -705,6 +705,29 @@ fn speed_comparison_sort_order() {
         ));
 }
 
+// Regression test for https://github.com/sharkdp/hyperfine/issues/852
+#[test]
+fn csv_export_reference_command_with_parameters() {
+    hyperfine_debug()
+        .arg("--style=none")
+        .arg("--runs=1")
+        .arg("--reference=sleep 1")
+        .arg("--parameter-scan")
+        .arg("secs")
+        .arg("2")
+        .arg("3")
+        .arg("--export-csv")
+        .arg("-")
+        .arg("sleep {secs}")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with(
+            r#"
+command,mean,stddev,median,user,system,min,max,parameter_secs
+sleep 1,1,0,1,0,0,1,1,"#, // Ends in empty value
+        ));
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_quote_args() {


### PR DESCRIPTION
Fixes #852

The problem was that the first command result was used to create the parameter CSV headers, even though this could be the reference command (which has no params). Here I find the first result with non-empty params and use it instead.

For the reference command, I export an empty value for each parameter to match the number of columns. IMO this is correct since the reference command has no parameter values. #877 uses lookup to print each column; I avoid this since iterating is cheaper and a reference command is very rare compared to parametrized commands.