### PR TITLE
Add shell completion generation command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.8"
 shell-words = "1.0"
 thiserror = "2.0"
 anyhow = "1.0"
+clap_complete = "4.2.1"
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use clap_complete::{generate_to, Shell};
+use clap_complete::generate_to;
 
 include!("src/cli.rs");
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,10 @@
 use std::ffi::OsString;
 
 use clap::{
-    builder::NonEmptyStringValueParser, crate_version, Arg, ArgAction, ArgMatches, Command,
-    ValueHint,
+    builder::NonEmptyStringValueParser, crate_version, value_parser, Arg, ArgAction, ArgMatches,
+    Command, ValueHint,
 };
+use clap_complete::shells::Shell;
 
 pub fn get_cli_arguments<'a, I, T>(args: I) -> ArgMatches
 where
@@ -15,7 +16,7 @@ where
 }
 
 /// Build the clap command for parsing command line arguments
-fn build_command() -> Command {
+pub fn build_command() -> Command {
     Command::new("hyperfine")
         .version(crate_version!())
         .next_line_help(true)
@@ -23,6 +24,17 @@ fn build_command() -> Command {
         .about("A command-line benchmarking tool.")
         .help_expected(true)
         .max_term_width(80)
+        .subcommand_negates_reqs(true)
+        .subcommand(
+            Command::new("generate-shell-completion")
+                .about("Generate shell completion scripts")
+                .arg(
+                    Arg::new("shell")
+                        .help("The shell to generate completions for.")
+                        .required(true)
+                        .value_parser(value_parser!(Shell)),
+                ),
+        )
         .arg(
             Arg::new("command")
                 .help("The command to benchmark. This can be the name of an executable, a command \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use std::ffi::OsString;
 
 use clap::{
-    builder::NonEmptyStringValueParser, crate_version, value_parser, Arg, ArgAction, ArgMatches,
-    Command, ValueHint,
+    builder::NonEmptyStringValueParser, crate_version, error::ErrorKind, value_parser, Arg,
+    ArgAction, ArgMatches, Command, ValueHint,
 };
 use clap_complete::shells::Shell;
 
@@ -11,7 +11,26 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone + 'a,
 {
-    let command = build_command();
+    let mut command = build_command();
+    let args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+
+    if let Some(subcommand_index) = args
+        .iter()
+        .position(|arg| arg == "generate-shell-completion")
+        .filter(|index| *index > 1)
+    {
+        command
+            .error(
+                ErrorKind::ArgumentConflict,
+                format!(
+                    "the argument '{}' cannot be used with the subcommand '{}'",
+                    args[subcommand_index - 1].to_string_lossy(),
+                    args[subcommand_index].to_string_lossy()
+                ),
+            )
+            .exit();
+    }
+
     command.get_matches_from(args)
 }
 
@@ -25,6 +44,8 @@ pub fn build_command() -> Command {
         .help_expected(true)
         .max_term_width(80)
         .subcommand_negates_reqs(true)
+        .args_conflicts_with_subcommands(true)
+        .subcommand_precedence_over_arg(true)
         .subcommand(
             Command::new("generate-shell-completion")
                 .about("Generate shell completion scripts")

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,13 @@
 use std::env;
 
 use benchmark::scheduler::Scheduler;
-use cli::get_cli_arguments;
+use cli::{build_command, get_cli_arguments};
 use command::Commands;
 use export::ExportManager;
 use options::Options;
 
 use anyhow::Result;
+use clap_complete::{generate, shells::Shell};
 use colored::*;
 
 pub mod benchmark;
@@ -32,6 +33,15 @@ fn run() -> Result<()> {
     colored::control::set_virtual_terminal(true).unwrap();
 
     let cli_arguments = get_cli_arguments(env::args_os());
+    if let Some(("generate-shell-completion", subcommand)) = cli_arguments.subcommand() {
+        let shell = subcommand
+            .get_one::<Shell>("shell")
+            .expect("required by clap");
+        let mut command = build_command();
+        generate(*shell, &mut command, "hyperfine", &mut std::io::stdout());
+        return Ok(());
+    }
+
     let mut options = Options::from_cli_arguments(&cli_arguments)?;
     let commands = Commands::from_cli_arguments(&cli_arguments)?;
     let export_manager = ExportManager::from_cli_arguments(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -45,6 +45,17 @@ fn rejects_unknown_shell_completion() {
 }
 
 #[test]
+fn rejects_benchmark_command_with_shell_completion_subcommand() {
+    hyperfine()
+        .arg("echo ok")
+        .arg("generate-shell-completion")
+        .arg("fish")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
 fn one_run_is_supported() {
     hyperfine()
         .arg("--runs=1")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25,6 +25,26 @@ fn runs_successfully() {
 }
 
 #[test]
+fn generates_shell_completion() {
+    hyperfine()
+        .arg("generate-shell-completion")
+        .arg("fish")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete").and(predicate::str::contains("hyperfine")));
+}
+
+#[test]
+fn rejects_unknown_shell_completion() {
+    hyperfine()
+        .arg("generate-shell-completion")
+        .arg("unknown")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value 'unknown'"));
+}
+
+#[test]
 fn one_run_is_supported() {
     hyperfine()
         .arg("--runs=1")


### PR DESCRIPTION
## Summary
- add a `generate-shell-completion <SHELL>` subcommand that writes completions to stdout
- reuse the existing Clap command definition and `clap_complete` shell support used by the build script
- add integration coverage for completion generation and invalid shell handling

Fixes #881.

## Validation
- `cargo fmt --check`
- `cargo test --test integration_tests shell_completion`
- `cargo test`
- `cargo run --quiet -- generate-shell-completion fish > /tmp/...` and verified the output contains Fish completion entries for `hyperfine`
- `git diff --check`
