### PR TITLE
docs: update stale version metadata (CITATION.cff 1.16.1→1.20.0, README MSRV 1.76→1.88)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,5 +13,5 @@ authors:
 repository-code: 'https://github.com/sharkdp/hyperfine'
 abstract: A command-line benchmarking tool.
 license: MIT
-version: 1.16.1
-date-released: '2023-03-21'
+version: 1.20.0
+date-released: '2025-11-18'

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Hyperfine can be installed from source via [cargo](https://doc.rust-lang.org/car
 cargo install --locked hyperfine
 ```
 
-Make sure that you use Rust 1.76 or newer.
+Make sure that you use Rust 1.88 or newer.
 
 ### From binaries (Linux, macOS, Windows)
 


### PR DESCRIPTION
Hi, and thank you for hyperfine.

Two small stale-metadata fixes:

**1. `CITATION.cff`** still points at the 2023 release:
```
version: 1.16.1
date-released: '2023-03-21'
```
The current release is `v1.20.0` (2025-11-18, matching `Cargo.toml` `version = "1.20.0"`), so citations generated from this file reference a 2-year-old version. Updated `version` and `date-released` to match the latest release.

**2. `README.md` (line 308)** says *"Make sure that you use Rust 1.76 or newer."* but `Cargo.toml` declares `rust-version = "1.88.0"`, so 1.76 no longer builds it. Updated to 1.88.

For transparency: I used AI assistance to spot and draft this; I verified `CITATION.cff`, the latest release, `Cargo.toml`, and the README against the current source myself.
