### PR TITLE
ci: add native Windows ARM64 releases

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -84,8 +84,8 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-2022                  }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-24.04, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-24.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-15-intel                }
-          - { target: aarch64-apple-darwin        , os: macos-latest                  }
+          - { target: x86_64-apple-darwin         , os: macos-15                      }
+          - { target: aarch64-apple-darwin        , os: macos-15                      }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }
           - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -84,10 +84,11 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-2022                  }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-24.04, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-24.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-15                      }
-          - { target: aarch64-apple-darwin        , os: macos-15                      }
+          - { target: x86_64-apple-darwin         , os: macos-15-intel                }
+          - { target: aarch64-apple-darwin        , os: macos-latest                  }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022                  }
+          - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04, use-cross: true }
     env:
@@ -159,7 +160,7 @@ jobs:
       run: |
         # test only library unit tests and binary for arm-type targets
         unset CARGO_TEST_OPTIONS
-        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--bin ${{ steps.bin.outputs.BIN_NAME }}" ;; esac;
+        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--bin ${{ needs.crate_metadata.outputs.bin-name }}" ;; esac;
         echo "CARGO_TEST_OPTIONS=${CARGO_TEST_OPTIONS}" >> $GITHUB_OUTPUT
 
     - name: Run tests


### PR DESCRIPTION
## Summary

- add aarch64-pc-windows-msvc on the native windows-11-arm runner
- select explicit native runners for Intel and ARM macOS builds
- fix the ARM test option to use the crate metadata output

## Validation

The full release matrix passed in my fork, including Windows ARM64 build, tests, packaging, and artifact upload:
https://github.com/meop/hyperfine/actions/runs/31940524952

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the resulting diff and validated it through the linked GitHub Actions run.